### PR TITLE
Upgrade to sbt-bundle 0.3.0 because of start-status-command

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Version {
   val jansi            = "1.11"
   val jline            = "2.12"
   val play             = "2.4.0-M1"
-  val sbtBundle        = "0.2.0"
+  val sbtBundle        = "0.3.0"
   val scalaTest        = "2.2.2"
   val scalactic        = "2.2.2"
 }

--- a/src/main/scala/com/typesafe/reactiveruntime/sbt/SbtReactiveRuntime.scala
+++ b/src/main/scala/com/typesafe/reactiveruntime/sbt/SbtReactiveRuntime.scala
@@ -59,7 +59,7 @@ object SbtReactiveRuntime extends AutoPlugin {
 
   val autoImport = Import
 
-  override def requires: Plugins =
+  override def `requires`: Plugins =
     plugins.CorePlugin
 
   override def globalSettings: Seq[Setting[_]] =


### PR DESCRIPTION
Once [PR 4 against sbt-bundle](https://github.com/sbt/sbt-bundle/pull/4) has been merged and a 0.3.0 release has been created, merge this PR and create a 0.7.0 release.
