### PR TITLE
Drop LagomBundleKeys.endpointsPort

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/LagomBundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomBundleImport.scala
@@ -10,11 +10,5 @@ object LagomBundleImport {
 
   object LagomBundleKeys {
     val conductrBundleLibVersion = BaseKeys.conductrBundleLibVersion
-
-    @deprecated("This setting is no longer used as endpoint port is not of Bundle Endpoint declaration using HTTP request ACL", since = "2.0.0")
-    val endpointsPort = SettingKey[Int](
-      "lagom-bundle-endpoints-port",
-      "Declares the port for each service endpoint that gets exposed to the outside world, e.g. http://:9000/myservice. Defaults to 9000."
-    )
   }
 }

--- a/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
@@ -41,7 +41,6 @@ object LagomBundlePlugin extends AutoPlugin {
       BundleKeys.nrOfCpus := PlayBundleKeyDefaults.nrOfCpus,
       BundleKeys.memory := PlayBundleKeyDefaults.memory,
       BundleKeys.diskSpace := PlayBundleKeyDefaults.diskSpace,
-      endpointsPort := 9000,
       ivyConfigurations += apiToolsConfig,
       // scalaBinaryVersion.value uses the binary compatible scala version from the Lagom project
       conductrBundleLibVersion := "1.4.2",


### PR DESCRIPTION
`LagomBundleKeys.endpointsPort` is deprecated. However, we set a default for this key in `LagomBundlePlugin`. Therefore for every Lagom project we currently get a warning that this key is depracted.

Instead we can remove this key because this change will be released as the version 2.0.0. This indicates that this is a breaking change.