### PR TITLE
Bump ConductR version to 1.1.3

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -58,7 +58,7 @@ object ConductrPlugin extends AutoPlugin {
       discoveredConfigDist <<= (dist in BundleConfiguration).storeAs(discoveredConfigDist).triggeredBy(dist in BundleConfiguration)
     )
 
-  private final val LatestConductrVersion = "1.1.2"
+  private final val LatestConductrVersion = "1.1.3"
   private final val LatestConductrDocVersion = LatestConductrVersion.dropRight(1) :+ "x" // 1.0.0 to 1.0.x
 
   private final val TypesafePropertiesName = "typesafe.properties"

--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -132,7 +132,7 @@ object ConductrPlugin extends AutoPlugin {
    * Executes the `sandbox run` command of the conductr-cli.
    */
   def sandboxRun(
-    conductrImageVersion: Option[String] = Some(LatestConductrVersion),
+    conductrImageVersion: Option[String],
     conductrImage: Option[String] = None,
     nrOfContainers: Option[Int] = None,
     features: Set[String] = Set.empty,


### PR DESCRIPTION
Update `LatestConductrVersion` from 1.1.2 to 1.1.3.

Also removing the default from `conductrImageVersion`. As a consequence `sandbox run` is not picking up the latest ConductR image version anymore. Instead this error message is displayed:

```
The version of the ConductR Docker image must be set.
Please visit https://www.typesafe.com/product/conductr/developer to obtain the current version information.
```

This is the same behavior as one the conductr-cli.