### PR TITLE
Introduces the install and generateInstallationScript commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ sbt-conductr contains several sbt auto plugins. The following table provides an 
 
 | Plugin                | Description                                                                    | Scope   | Trigger
 |-----------------------|--------------------------------------------------------------------------------|---------|--------- 
-| ConductRPlugin        | Uses the conductr-cli commands to manage a ConductR cluster                    | Global  | Always enabled
+| ConductrPlugin        | Uses the conductr-cli commands to manage a ConductR cluster                    | Global  | Always enabled
 | BundlePlugin          | Produce a bundle and bundle configuration for a JavaAppPackaing application.   | Project | JavaAppPackaging
 | PlayBundlePlugin      | Produce a bundle and bundle configuration for a Play application.              | Project | Play && BundlePlugin
 | LagomPlayBundlePlugin | Produce a bundle and bundle configuration for a Play application inside a Lagom project. | Project | LagomPlay && BundlePlugin
 | LagomBundlePlugin     | Produce a bundle and bundle configuration for a Lagom service.                 | Project | LagomJava && BundlePlugin
+| LagomConductrPlugin   | Adds Lagom concerns to ConductrPlugin                                          | Global  | ConductrPlugin && LagomBundlePlugin
 
 The `ConductRPlugin` is enabled as soon as `sbt-conductr` has been added to the project. The `BundlePlugin` is triggered for each project that enables a native packager plugin in the `build.sbt`, e.g.:
 
@@ -74,8 +75,8 @@ bundle:dist                  | Produce a ConductR bundle for all projects that h
 configuration:dist           | Produce a bundle configuration for all projects that have the native packager enabled
 cassandra:configuration:dist | Produce one cassandra bundle configuration in the root target directory
 sandbox help                 | Get usage information of the sandbox command
-sandbox run                  | Start a local ConductR cluster
-sandbox stop                 | Stop the local ConductR cluster
+sandbox run                  | Start a local ConductR sandbox
+sandbox stop                 | Stop the local ConductR sandbox
 conduct help                 | Get usage information of the conduct command
 conduct info                 | Gain information on the cluster
 conduct load                 | Loads a bundle and an optional configuration to the ConductR
@@ -84,6 +85,7 @@ conduct stop                 | Stops all executions of a bundle given a bundle i
 conduct unload               | Unloads a bundle entirely (requires that the bundle has stopped executing everywhere)
 conduct logs                 | Retrieves log messages of a given bundle
 conduct events               | Retrieves events of a given bundle
+install                      | Generates an installation script and then installs all of your projects to the local ConductR sandbox (expected to be running)
 
 Each `sandbox` and `conduct` sub command has a help page particular for the sub command, e.g. `conduct run --help`.
 
@@ -130,6 +132,16 @@ To stop the ConductR sandbox use:
 ```
 sandbox stop
 ```
+
+### Installing your project
+
+The `install` command will introspect your project and its sub-projects and then load and run everything in ConductR at once. The local sandbox is expected to be running and it will first be restarted to ensure that it is in a clean state.
+
+### Generating an installation script
+
+Just like the `install` command, the `generateInstallationScript` command also introspects your project but then writes what is required to load and run everything to a script. The command will output the location of the generated script once done. You are encouraged to copy this script and use it as the basis of installing your project for production deployments.
+
+You can run the script as many times as you need; ConductR load and run commands are idempotent thus allowing you to conveniently load and run any individual components that have stopped for some reason.
 
 ### Retrieving bundle state
 

--- a/sbt-conductr-tester/lagom-bundle/lagom-service-api/src/main/java/api/FooService.java
+++ b/sbt-conductr-tester/lagom-bundle/lagom-service-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
     return named("fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/sbt-conductr-tester/lagom-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRImport.scala
@@ -4,32 +4,74 @@
 
 package com.lightbend.conductr.sbt
 
+import java.nio.file.Path
+
 import sbt._
 
 object ConductrImport {
 
+  object InstallationData {
+    /**
+     * Flatten our Either type to a string.
+     */
+    def nameOrPath(e: Either[String, Path]): String =
+      e match {
+        case Left(v)  => v
+        case Right(v) => v.toString
+      }
+  }
+
+  /**
+   * Provides the data required to load and run a bundle
+   * @param bundleName the normalized name of the bundle
+   * @param bundleFile the bundle for resolving or a file path
+   * @param bundleConfigFile and optional configuration bundle file
+   */
+  case class InstallationData(
+    bundleName: String,
+    bundleFile: Either[String, Path],
+    bundleConfigFile: Option[Path]
+  )
+
   object ConductrKeys {
 
-    // Sandbox keys
     val hasRpLicense = SettingKey[Boolean](
       "conductr-has-rp-license",
       "Checks that the project has a reactive platform license"
     )
+
     val isSbtBuild = SettingKey[Boolean](
       "conductr-is-sbt-build",
       "True if the project is THE sbt build project."
     )
+
     val sandbox = inputKey[Unit]("Sandbox task")
 
-    // Conduct keys
     val discoveredDist = TaskKey[File](
       "conductr-discoverd-dist",
       "Any distribution produced by the current project"
     )
+
     val discoveredConfigDist = TaskKey[File](
       "conductr-discovered-config-dist",
       "Any additional configuration distribution produced by the current project"
     )
+
     val conduct = inputKey[Unit]("Conduct task")
+
+    val installationData = TaskKey[Seq[InstallationData]](
+      "conductr-installation-data",
+      "Returns an array of InstallationData containing the information for installing an entire build's bundles"
+    )
+
+    val generateInstallationScript = TaskKey[File](
+      "generate-installation-script",
+      "Produces the installation script to install the entire build's bundles"
+    )
+
+    val install = TaskKey[Unit](
+      "install",
+      "Installs an entire build's bundles"
+    )
   }
 }

--- a/src/main/scala/com/lightbend/conductr/sbt/LagomBundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomBundleImport.scala
@@ -1,12 +1,11 @@
 package com.lightbend.conductr.sbt
 
-import com.typesafe.sbt.SbtNativePackager.Universal
 import sbt._
 
 object LagomBundleImport {
 
   // Configuration to produce a bundle configuration for cassandra
-  val CassandraConfiguration = config("cassandra-configuration") extend Universal
+  val CassandraConfiguration = config("cassandra-configuration") extend BundleImport.BundleConfiguration
 
   object LagomBundleKeys {
     val conductrBundleLibVersion = BaseKeys.conductrBundleLibVersion

--- a/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
@@ -42,8 +42,7 @@ object LagomPlayBundlePlugin extends AutoPlugin {
       BundleKeys.diskSpace := PlayBundleKeyDefaults.diskSpace,
       BundleKeys.endpoints := BundlePlugin.getDefaultWebEndpoints(Bundle).value,
       LagomBundleKeys.conductrBundleLibVersion := Version.conductrBundleLib,
-      libraryDependencies += Library.lagomConductrBundleLib(LagomVersion.current, scalaBinaryVersion.value, LagomBundleKeys.conductrBundleLibVersion.value),
-      resolvers += Resolver.typesafeBintrayReleases
+      libraryDependencies += Library.lagomConductrBundleLib(LagomVersion.current, scalaBinaryVersion.value, LagomBundleKeys.conductrBundleLibVersion.value)
     )
 }
 
@@ -86,7 +85,6 @@ object LagomBundlePlugin extends AutoPlugin {
         LagomImport.component("api-tools") % apiToolsConfig,
         Library.lagomConductrBundleLib(LagomVersion.current, scalaBinaryVersion.value, LagomBundleKeys.conductrBundleLibVersion.value)
       ),
-      resolvers += Resolver.typesafeBintrayReleases,
       manageClasspath(apiToolsConfig)
     )
 
@@ -154,7 +152,7 @@ object LagomBundlePlugin extends AutoPlugin {
   private def stageCassandraConfiguration(config: Configuration, filter: ScopeFilter): Def.Initialize[Task[File]] = Def.task {
     val configurationTarget = (NativePackagerKeys.stagingDirectory in config).value / config.name
     // Use acls if in any of the projects 'enableAcls' is set to 'true'
-    val enableAcls = (BundleKeys.enableAcls in Bundle).?.map(_.getOrElse(false)).all(filter).value.exists(_ == true)
+    val enableAcls = (BundleKeys.enableAcls in Bundle).?.map(_.getOrElse(false)).all(filter).value.contains(true)
     val resourcePath = if (enableAcls) "bundle-configuration/cassandra-acls" else "bundle-configuration/cassandra-services"
     val jarFile = new File(this.getClass.getProtectionDomain.getCodeSource.getLocation.getPath)
     if (jarFile.isFile) {

--- a/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomBundlePlugin.scala
@@ -91,7 +91,7 @@ object LagomBundlePlugin extends AutoPlugin {
     )
 
   override def buildSettings =
-    super.buildSettings ++ cassandraConfigurationSettings(CassandraConfiguration)
+    cassandraConfigurationSettings(CassandraConfiguration)
 
   /**
    * Override bundle settings from sbt-bundle with the collected Lagom endpoints

--- a/src/main/scala/com/lightbend/conductr/sbt/LagomConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/LagomConductRPlugin.scala
@@ -1,0 +1,33 @@
+package com.lightbend.conductr.sbt
+
+import sbt._
+
+import com.typesafe.sbt.SbtNativePackager
+
+/**
+ * Adds Lagom concerns to the ConductR plugin
+ */
+object LagomConductRPlugin extends AutoPlugin {
+
+  import ConductrPlugin.autoImport._
+  import ConductrKeys._
+
+  import LagomBundlePlugin.autoImport._
+
+  import SbtNativePackager.autoImport._
+  import NativePackagerKeys._
+
+  override def requires = ConductrPlugin && LagomBundlePlugin
+
+  override def trigger = allRequirements
+
+  override def buildSettings: Seq[Setting[_]] =
+    List(
+      installationData ++= installationDataTask.value
+    )
+
+  private def installationDataTask: Def.Initialize[Task[Seq[InstallationData]]] = Def.task {
+    val cassandraConfigPath = (dist in CassandraConfiguration).value.toPath
+    List(InstallationData("cassandra", Left("cassandra"), Some(cassandraConfigPath)))
+  }
+}

--- a/src/main/scala/com/lightbend/conductr/sbt/PlayBundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/PlayBundlePlugin.scala
@@ -33,8 +33,7 @@ object PlayBundlePlugin extends AutoPlugin {
       BundleKeys.diskSpace := PlayBundleKeyDefaults.diskSpace,
       BundleKeys.endpoints := BundlePlugin.getDefaultWebEndpoints(Bundle).value,
       conductrBundleLibVersion := Version.conductrBundleLib,
-      libraryDependencies += Library.playConductrBundleLib(PlayVersion.current, scalaBinaryVersion.value, conductrBundleLibVersion.value),
-      resolvers += Resolver.typesafeBintrayReleases
+      libraryDependencies += Library.playConductrBundleLib(PlayVersion.current, scalaBinaryVersion.value, conductrBundleLibVersion.value)
     )
 }
 

--- a/src/main/scala/com/lightbend/conductr/sbt/package.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/package.scala
@@ -3,7 +3,6 @@ package com.lightbend.conductr
 import java.lang.reflect.InvocationTargetException
 import java.nio.charset.Charset
 import _root_.sbt._
-import _root_.sbt.Resolver.bintrayRepo
 import scala.reflect.ClassTag
 import scala.util.Try
 import scala.annotation.tailrec
@@ -63,10 +62,6 @@ package object sbt {
       }
   }
 
-  object Resolver {
-    val typesafeBintrayReleases = bintrayRepo("typesafe", "maven-releases")
-  }
-
   object Library {
     def playConductrBundleLib(playVersion: String, scalaVersion: String, conductrLibVersion: String) =
       "com.typesafe.conductr" % s"play${formatVersion(playVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
@@ -78,7 +73,7 @@ package object sbt {
   }
 
   object Version {
-    val conductrBundleLib = "1.4.3"
+    val conductrBundleLib = "1.4.4"
   }
 
   /**
@@ -87,7 +82,7 @@ package object sbt {
   object BaseKeys {
     val conductrBundleLibVersion = SettingKey[String](
       "play-bundle-conductr-bundle-lib-version",
-      "The version of conductr-bundle-lib to depend on. Defaults to 1.4.3"
+      "The version of conductr-bundle-lib to depend on. Defaults to 1.4.4"
     )
   }
 

--- a/src/sbt-test/bundle-plugin/checks/build.sbt
+++ b/src/sbt-test/bundle-plugin/checks/build.sbt
@@ -46,7 +46,7 @@ checkBundleConf := {
                             |  checks-status = {
                             |    description      = "Status check for the bundle component"
                             |    file-system-type = "universal"
-                            |    start-command    = ["check", "--initial-delay", "2", "$CHECKS_HOST?retry-count=5&retry-delay=3"]
+                            |    start-command    = ["check", "--initial-delay", "1", "$CHECKS_HOST?retry-count=5&retry-delay=3"]
                             |    endpoints        = {}
                             |  }
                             |}""".stripMargin

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/simple-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/simple-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+    return named("fooservice").with(
+            restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/simple-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/simple-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/simple-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/simple-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+    return named("fooservice").with(
+            restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/simple-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/simple-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/credit-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/credit-api/src/main/java/api/CreditService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface CreditService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> credit();
+  ServiceCall<NotUsed, NotUsed> credit();
 
   @Override
   default Descriptor descriptor() {
     return named("creditservice").with(
-      restCall(Method.GET,  "/credit", credit())
+      restCall(Method.GET,  "/credit", this::credit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/credit-impl/src/main/java/impl/CreditServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/credit-impl/src/main/java/impl/CreditServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class CreditServiceImpl implements CreditService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> credit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> credit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/debit-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/debit-api/src/main/java/api/DebitService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface DebitService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> debit();
+  ServiceCall<NotUsed, NotUsed> debit();
 
   @Override
   default Descriptor descriptor() {
     return named("debitservice").with(
-      restCall(Method.GET,  "/debit", debit())
+      restCall(Method.GET,  "/debit", this::debit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/debit-impl/src/main/java/impl/DebitServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/debit-impl/src/main/java/impl/DebitServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class DebitServiceImpl implements DebitService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> debit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> debit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-same-service-name/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/backend-api/src/main/java/api/BackendService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/backend-api/src/main/java/api/BackendService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface BackendService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> bar();
+  ServiceCall<NotUsed, NotUsed> bar();
 
   @Override
   default Descriptor descriptor() {
     return named("backendservice").with(
-      restCall(Method.GET,  "/bar", bar())
+      restCall(Method.GET,  "/bar", this::bar)
     );
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/backend-impl/src/main/java/impl/BackendServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/backend-impl/src/main/java/impl/BackendServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class BackendServiceImpl implements BackendService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> bar() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> bar() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/frontend-api/src/main/java/api/FrontendService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/frontend-api/src/main/java/api/FrontendService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FrontendService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
     return named("frontendservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET,  "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/frontend-impl/src/main/java/impl/FrontendServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/frontend-impl/src/main/java/impl/FrontendServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FrontendServiceImpl implements FrontendService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-api/src/main/java/api/CreditService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface CreditService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> credit();
+  ServiceCall<NotUsed, NotUsed> credit();
 
   @Override
   default Descriptor descriptor() {
     return named("/creditservice").with(
-      restCall(Method.GET,  "/", credit())
+      restCall(Method.GET,  "/", this::credit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-api/src/main/java/api/DebitService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface DebitService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> debit();
+  ServiceCall<NotUsed, NotUsed> debit();
 
   @Override
   default Descriptor descriptor() {
     return named("/debitservice").with(
-      restCall(Method.GET,  "/", debit())
+      restCall(Method.GET,  "/", this::debit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-impl/src/main/java/impl/CreditServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-impl/src/main/java/impl/CreditServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class CreditServiceImpl implements CreditService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> credit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> credit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-impl/src/main/java/impl/DebitServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/payment-impl/src/main/java/impl/DebitServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class DebitServiceImpl implements DebitService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> debit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> debit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/social-api/src/main/java/api/FeedService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/social-api/src/main/java/api/FeedService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FeedService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> feed();
+  ServiceCall<NotUsed, NotUsed> feed();
 
   @Override
   default Descriptor descriptor() {
     return named("/socialservice").with(
-      restCall(Method.GET,  "/", feed())
+      restCall(Method.GET,  "/", this::feed)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/social-impl/src/main/java/impl/FeedServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/social-impl/src/main/java/impl/FeedServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FeedServiceImpl implements FeedService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> feed() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> feed() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-api/src/main/java/api/CreditService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface CreditService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> credit();
+  ServiceCall<NotUsed, NotUsed> credit();
 
   @Override
   default Descriptor descriptor() {
     return named("paymentservice").with(
-      restCall(Method.GET,  "/credit", credit())
+      restCall(Method.GET,  "/credit", this::credit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-api/src/main/java/api/DebitService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface DebitService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> debit();
+  ServiceCall<NotUsed, NotUsed> debit();
 
   @Override
   default Descriptor descriptor() {
     return named("paymentservice").with(
-      restCall(Method.GET,  "/debit", debit())
+      restCall(Method.GET,  "/debit", this::debit)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/CreditServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/CreditServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class CreditServiceImpl implements CreditService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> credit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> credit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/DebitServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/DebitServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class DebitServiceImpl implements DebitService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> debit() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> debit() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-api/src/main/java/api/BarService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-api/src/main/java/api/BarService.java
@@ -11,14 +11,14 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface BarService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> getBar();
-  ServiceCall<NotUsed, NotUsed, NotUsed> addBar();
+  ServiceCall<NotUsed, NotUsed> getBar();
+  ServiceCall<NotUsed, NotUsed> addBar();
 
   @Override
   default Descriptor descriptor() {
     return named("barservice").with(
-      restCall(Method.GET,  "/bar", getBar()),
-      restCall(Method.POST, "/bar", addBar())
+      restCall(Method.GET,  "/bar", this::getBar),
+      restCall(Method.POST, "/bar", this::addBar)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
@@ -11,16 +11,16 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foos();
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
-  ServiceCall<NotUsed, NotUsed, NotUsed> fooFriends();
+  ServiceCall<NotUsed, NotUsed> foos();
+  ServiceCall<NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> fooFriends();
 
   @Override
   default Descriptor descriptor() {
     return named("fooservice").with(
-      restCall(Method.GET,  "/foo", foos()),
-      restCall(Method.GET,  "/foo/:id", foo()),
-      restCall(Method.GET,  "/foo/:id/friends", fooFriends())
+      restCall(Method.GET,  "/foo", this::foos),
+      restCall(Method.GET,  "/foo/:id", this::foo),
+      restCall(Method.GET,  "/foo/:id/friends", this::fooFriends)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-impl/src/main/java/impl/BarServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-impl/src/main/java/impl/BarServiceImpl.java
@@ -11,15 +11,11 @@ import akka.stream.javadsl.Source;
 public class BarServiceImpl implements BarService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> getBar() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> getBar() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 
-  public ServiceCall<NotUsed, NotUsed, NotUsed> addBar() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> addBar() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/multi-services-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,23 +11,17 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foos() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foos() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> fooFriends() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> fooFriends() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
     return named("fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/simple/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/simple/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/simple/simple-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/simple/simple-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+    return named("fooservice").with(
+            restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/simple/simple-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/simple/simple-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/project/plugins.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/simple-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/simple-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+    return named("fooservice").with(
+            restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/simple-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-bundle-plugin/with-service-endpoint/simple-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/build.sbt
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/build.sbt
@@ -1,0 +1,26 @@
+import org.scalatest.Matchers._
+
+scalaVersion in ThisBuild := "2.11.7"
+version in ThisBuild := "0.1.0-SNAPSHOT"
+
+lazy val `lagom-service-api` = (project in file("lagom-service-api"))
+  .settings(libraryDependencies += lagomJavadslApi)
+
+lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
+  .enablePlugins(LagomJava)
+  .dependsOn(`lagom-service-api`)
+
+lazy val `play-service` = (project in file("play-service"))
+  .enablePlugins(PlayJava, LagomPlay)
+
+// Test assertions
+val verifyConductInfo = taskKey[Unit]("")
+verifyConductInfo := {
+  val output = conductInfo()
+  output should include("lagom-service-impl")
+  output should include("play-service")
+  output should include("cassandra")
+}
+
+def conductInfo(): String =
+  (Process("conduct info") #| Process(Seq("awk", "{print $2}"))).!!

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
@@ -1,0 +1,22 @@
+package api;
+
+import akka.stream.javadsl.Source;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+public interface FooService extends Service {
+
+  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+
+  @Override
+  default Descriptor descriptor() {
+    return named("fooservice").with(
+      restCall(Method.GET,  "/foo", foo())
+    ).withAutoAcl(true);
+  }
+}

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
     return named("fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -1,0 +1,19 @@
+package impl;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import api.FooService;
+
+import akka.stream.javadsl.Source;
+
+public class FooServiceImpl implements FooService {
+
+  @Override
+  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
+    return (id, request) -> {
+      return CompletableFuture.completedFuture(NotUsed.getInstance());
+    };
+  }
+}

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/Module.java
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/java/impl/Module.java
@@ -1,0 +1,16 @@
+package impl;
+
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import api.FooService;
+import play.*;
+import javax.inject.Inject;
+import java.util.Date;
+import java.io.*;
+
+public class Module extends AbstractModule implements ServiceGuiceSupport {
+	@Override
+	protected void configure() {
+		bindServices(serviceBinding(FooService.class, FooServiceImpl.class));
+	}
+}

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/resources/application.conf
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/lagom-service-impl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.modules.enabled += impl.Module

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/app/controllers/MyController.scala
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/app/controllers/MyController.scala
@@ -1,0 +1,14 @@
+package controllers
+
+import javax.inject._
+import play.api._
+import play.api.mvc._
+
+@Singleton
+class MyController @Inject() extends Controller {
+
+  def index = Action {
+    Ok("Hello world")
+  }
+
+}

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/bundle-configuration/default/runtime-config.sh
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/bundle-configuration/default/runtime-config.sh
@@ -1,0 +1,1 @@
+export APPLICATION_SECRET="thisismyapplicationsecret-pleasedonttellanyone"

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/application.conf
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/application.conf
@@ -1,0 +1,4 @@
+play.crypto.secret = "changeme"
+play.crypto.secret = ${?APPLICATION_SECRET}
+
+play.i18n.langs = ["en"]

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/logback.xml
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/logback.xml
@@ -1,0 +1,41 @@
+<!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
+<configuration>
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${application.home:-.}/logs/application.log</file>
+    <encoder>
+      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
+  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
+  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+
+</configuration>

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/routes
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/play-service/conf/routes
@@ -1,0 +1,4 @@
+GET     /                           controllers.MyController.index
+
+# Map static resources from the /public folder to the /assets URL path
+GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/build.properties
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/plugins.sbt
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/plugins.sbt
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/test
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/test
@@ -1,0 +1,11 @@
+> sandbox run 1.1.5
+
+> install
+$ sleep 5000
+
+> verifyConductInfo
+
+> sandbox stop
+
+> generateInstallationScript
+$ exists target/install.sh

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/build.sbt
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/build.sbt
@@ -15,16 +15,14 @@ BundleKeys.diskSpace := 5.MB
 
 val verifyConductLoad = taskKey[Unit]("")
 verifyConductLoad := {
-  conductInfo() should include("""NAME                           #REP  #STR  #RUN
-                               |reactive-maps-backend-region      1     0     0
-                               |reactive-maps-backend-summary     1     0     0""".stripMargin)
+  conductInfo() should include("""reactive-maps-backend-region      1     0     0
+                                 |reactive-maps-backend-summary     1     0     0""".stripMargin)
 }
 
 val verifyConductRun = taskKey[Unit]("")
 verifyConductRun := {
-  conductInfo() should include("""NAME                           #REP  #STR  #RUN
-                               |reactive-maps-backend-region      1     0     1
-                               |reactive-maps-backend-summary     1     0     1""".stripMargin)
+  conductInfo() should include("""reactive-maps-backend-region      1     0     1
+                                 |reactive-maps-backend-summary     1     0     1""".stripMargin)
 }
 
 val verifyConductStop = taskKey[Unit]("")

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/test
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/test
@@ -1,5 +1,5 @@
 # run sandbox
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 $ sleep 5000
 
 # conduct info

--- a/src/sbt-test/sbt-conductr/sandbox-all-args/test
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/test
@@ -7,11 +7,11 @@
 > sandbox run
 
 # sandbox long args
-> sandbox run 1.1.2 --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-containers 3 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
+> sandbox run 1.1.5 --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-containers 3 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
 > sandbox stop
 
 # sandbox short args
-> sandbox run 1.1.2 -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r frontend -r backend db -f visualization -f logging
+> sandbox run 1.1.5 -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r frontend -r backend db -f visualization -f logging
 > sandbox stop
 
 > checkConductrIsStopped

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
@@ -1,10 +1,10 @@
-> sandbox run 1.1.2 --nr-of-containers 3
+> sandbox run 1.1.5 --nr-of-containers 3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> sandbox run 1.1.2 --nr-of-containers 4 --conductr-role new-role --conductr-role other-role
+> sandbox run 1.1.5 --nr-of-containers 4 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-basic/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-basic/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2 --nr-of-containers 3 --port 1111 --port 2222
+> sandbox run 1.1.5 --nr-of-containers 3 --port 1111 --port 2222
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2 --port 1111 --port 2222
+> sandbox run 1.1.5 --port 1111 --port 2222
 
 > checkDockerContainers
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-scaling/test
+++ b/src/sbt-test/sbt-conductr/sandbox-scaling/test
@@ -1,12 +1,12 @@
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 
 > checkContainers1
 
-> sandbox run 1.1.2 --nr-of-containers 3
+> sandbox run 1.1.5 --nr-of-containers 3
 
 > checkContainers3
 
-> sandbox run 1.1.2 --nr-of-containers 2
+> sandbox run 1.1.5 --nr-of-containers 2
 
 > checkContainers2
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-features/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-features/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2 --feature visualization --feature logging
+> sandbox run 1.1.5 --feature visualization --feature logging
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/lagom-service-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/lagom-service-api/src/main/java/api/FooService.java
@@ -11,12 +11,12 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed> foo();
 
   @Override
   default Descriptor descriptor() {
     return named("fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET, "/foo", this::foo)
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,9 +11,7 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
-    return (id, request) -> {
-      return CompletableFuture.completedFuture(NotUsed.getInstance());
-    };
+  public ServiceCall<NotUsed, NotUsed> foo() {
+    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
   }
 }

--- a/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M2")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 
 > checkConductrIsRunning
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-play-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-play-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 
 > checkConductrIsRunning
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-scala-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-scala-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.2
+> sandbox run 1.1.5
 
 > checkConductrIsRunning
 


### PR DESCRIPTION
A new `install` command is provided that conveniently installs all of the bundles and their associated configurations (If present) to the local sandbox cluster. In addition, if the project is a Lagom one then the Cassandra configuration will be generated and loaded along with Cassandra.

A new `generateInstallationScript` command generates an installation script that is encouraged to be copied and used as the basis of a script that can manage a collection of bundles, in particular a collection that represents a system of micro services as is the case with Lagom.

Along the way, a new `waitForConductr` function is provided for public usage of the `ConductrBundle`. It is expected that ConductR's own acceptance tests can make use of this function in place of their custom logic.

The latest conductr-libs, now available from Maven, have also been included. The Lagom library is updated for milestone 2, and so that had a ripple effect on our tests which have therefore been modified.

Lastly, this PR fixes #142 by emitting a configuration file only when some configuration settings have been provided.