### PR TITLE
Using double quotes in docker command

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -170,7 +170,7 @@ object ConductrPlugin extends AutoPlugin {
 
   private def installTask(): Def.Initialize[Task[Unit]] = Def.task {
     withProcessHandling {
-      val nrOfContainers = "docker ps -q --filter='name=cond-'".lines_!.size
+      val nrOfContainers = """docker ps -q --filter="name=cond-"""".lines_!.size
       if (nrOfContainers > 0) {
         println("Restarting ConductR to ensure a clean state...")
         "docker exec cond-0 rm /opt/conductr/conf/seed-nodes".! // Allow the first node to form the new cluster


### PR DESCRIPTION
With docker 1.12 the single quote in the `docker ps` command was interpreted as two single quotes by docker and therefore resulted into this error:

```
Error response from daemon: Invalid filter ''name'
```

This PR fixes the error by using double quotes instead of single quotes.