### PR TITLE
Correct semver handling for image

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -73,7 +73,7 @@ object ConductrPlugin extends AutoPlugin {
       install := installTask().value
     )
 
-  private final val LatestConductrVersion = "1.1.6"
+  private final val LatestConductrVersion = "1.1.8-rc.1"
   private final val LatestConductrDocVersion = LatestConductrVersion.dropRight(1) :+ "x" // 1.0.0 to 1.0.x
 
   private final val TypesafePropertiesName = "typesafe.properties"
@@ -654,7 +654,7 @@ object ConductrPlugin extends AutoPlugin {
     def numberWithText(completionText: String): Parser[Int] =
       Space ~> token(IntBasic, completionText)
     def versionNumber(completionText: String): Parser[String] =
-      Space ~> token(identifier(charClass(_.isDigit), charClass(c => c == '.' || c.isDigit)), completionText)
+      Space ~> token(identifier(charClass(_.isDigit), charClass(c => c == '.' || c == '-' || c.isLetterOrDigit)), completionText)
     def withCompletionText(parser: Parser[String], completionText: String): Parser[String] =
       token(parser, completionText)
 

--- a/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/test
+++ b/src/sbt-test/lagom-conductr-bundle/play-and-lagom-service/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > install
 $ sleep 5000

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/test
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/test
@@ -1,5 +1,5 @@
 # run sandbox
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 $ sleep 5000
 
 # conduct info

--- a/src/sbt-test/sbt-conductr/sandbox-all-args/test
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/test
@@ -7,11 +7,11 @@
 > sandbox run
 
 # sandbox long args
-> sandbox run 1.1.5 --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-containers 3 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
+> sandbox run 1.1.8-rc.1 --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-containers 3 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
 > sandbox stop
 
 # sandbox short args
-> sandbox run 1.1.5 -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r frontend -r backend db -f visualization -f logging
+> sandbox run 1.1.8-rc.1 -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r frontend -r backend db -f visualization -f logging
 > sandbox stop
 
 > checkConductrIsStopped

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
@@ -1,10 +1,10 @@
-> sandbox run 1.1.5 --nr-of-containers 3
+> sandbox run 1.1.8-rc.1 --nr-of-containers 3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> sandbox run 1.1.5 --nr-of-containers 4 --conductr-role new-role --conductr-role other-role
+> sandbox run 1.1.8-rc.1 --nr-of-containers 4 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-basic/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-basic/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5 --nr-of-containers 3 --port 1111 --port 2222
+> sandbox run 1.1.8-rc.1 --nr-of-containers 3 --port 1111 --port 2222
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5 --port 1111 --port 2222
+> sandbox run 1.1.8-rc.1 --port 1111 --port 2222
 
 > checkDockerContainers
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/test
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-scaling/test
+++ b/src/sbt-test/sbt-conductr/sandbox-scaling/test
@@ -1,12 +1,12 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > checkContainers1
 
-> sandbox run 1.1.5 --nr-of-containers 3
+> sandbox run 1.1.8-rc.1 --nr-of-containers 3
 
 > checkContainers3
 
-> sandbox run 1.1.5 --nr-of-containers 2
+> sandbox run 1.1.8-rc.1 --nr-of-containers 2
 
 > checkContainers2
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-features/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-features/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5 --feature visualization --feature logging
+> sandbox run 1.1.8-rc.1 --feature visualization --feature logging
 
 > checkPorts
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-lagom-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > checkConductrIsRunning
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-play-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-play-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > checkConductrIsRunning
 

--- a/src/sbt-test/sbt-conductr/sandbox-with-scala-project/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-scala-project/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.5
+> sandbox run 1.1.8-rc.1
 
 > checkConductrIsRunning
 


### PR DESCRIPTION
ConductR images support semantic versioning, which also means the addition of a `-rc.1` style of suffix. Prior to this PR, declaring `sandbox run 1.1.8-rc.1` did not parse. It now does.