### PR TITLE
Latest conductr-lib

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/package.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/package.scala
@@ -73,7 +73,7 @@ package object sbt {
   }
 
   object Version {
-    val conductrBundleLib = "1.4.5"
+    val conductrBundleLib = "1.4.7"
   }
 
   /**
@@ -82,7 +82,7 @@ package object sbt {
   object BaseKeys {
     val conductrBundleLibVersion = SettingKey[String](
       "play-bundle-conductr-bundle-lib-version",
-      "The version of conductr-bundle-lib to depend on. Defaults to 1.4.5"
+      "The version of conductr-bundle-lib to depend on. Defaults to 1.4.7"
     )
   }
 


### PR DESCRIPTION
The latest conductr-lib fixes a problem where the service locator would cache the fact that an address could not be found.