### PR TITLE
Use Lagom major version only when resolving ConductR Bundle Lib for Lagom

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/package.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/package.scala
@@ -64,16 +64,19 @@ package object sbt {
 
   object Library {
     def playConductrBundleLib(playVersion: String, scalaVersion: String, conductrLibVersion: String) =
-      "com.typesafe.conductr" % s"play${formatVersion(playVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
+      "com.typesafe.conductr" % s"play${formatVersionMajorMinor(playVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
     def lagomConductrBundleLib(lagomVersion: String, scalaVersion: String, conductrLibVersion: String) =
-      "com.typesafe.conductr" % s"lagom${formatVersion(lagomVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
+      "com.typesafe.conductr" % s"lagom${formatVersionMajor(lagomVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
 
-    private def formatVersion(version: String) =
+    private def formatVersionMajorMinor(version: String): String =
       version.filterNot(_ == '.').take(2)
+
+    private def formatVersionMajor(version: String): String =
+      version.filterNot(_ == '.').take(1)
   }
 
   object Version {
-    val conductrBundleLib = "1.4.7"
+    val conductrBundleLib = "1.4.8"
   }
 
   /**
@@ -82,7 +85,7 @@ package object sbt {
   object BaseKeys {
     val conductrBundleLibVersion = SettingKey[String](
       "play-bundle-conductr-bundle-lib-version",
-      "The version of conductr-bundle-lib to depend on. Defaults to 1.4.7"
+      s"The version of conductr-bundle-lib to depend on. Defaults to ${Version.conductrBundleLib}"
     )
   }
 

--- a/src/test/scala/com/lightbend/conductr/sbt/PackageSpec.scala
+++ b/src/test/scala/com/lightbend/conductr/sbt/PackageSpec.scala
@@ -1,0 +1,18 @@
+package com.lightbend.conductr.sbt
+
+import _root_.sbt._
+import org.scalatest.{ Matchers, WordSpec }
+
+class PackageSpec extends WordSpec with Matchers {
+  "Library" should {
+    "return ConductR Lib support for Play" in {
+      val result = Library.playConductrBundleLib(playVersion = "2.5.6", scalaVersion = "2.11", conductrLibVersion = "1.1.3")
+      result shouldBe ("com.typesafe.conductr" % s"play25-conductr-bundle-lib_2.11" % "1.1.3")
+    }
+
+    "return ConductR Lib support for Lagom" in {
+      val result = Library.lagomConductrBundleLib(lagomVersion = "1.0.0", scalaVersion = "2.11", conductrLibVersion = "1.1.3")
+      result shouldBe ("com.typesafe.conductr" % s"lagom1-conductr-bundle-lib_2.11" % "1.1.3")
+    }
+  }
+}


### PR DESCRIPTION
This is due to the fact that Lagom will support semantic versioning, and hence all releases within the same major versions will be binary compatible.

Also upgrade to ConductR Bundle Lib 1.4.8 since ConductR Bundle Lib 1.4.8 has been made with Lagom's use of semantic versioning.