### PR TITLE
Fix sandbox run feature parser

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -354,8 +354,6 @@ object ConductrPlugin extends AutoPlugin {
     object Sandbox {
       import ArgumentConverters._
 
-      val availableFeatures = Set("visualization", "logging", "monitoring")
-
       // Sandbox parser
       lazy val subtask: Def.Initialize[State => Parser[SandboxSubtask]] = Def.value {
         case _ =>
@@ -430,11 +428,8 @@ object ConductrPlugin extends AutoPlugin {
         Space ~> (token(Flags.port) | hideAutoCompletion("-p")) ~> numberWithText("<port>").map(PortArg(_))
 
       def feature: Parser[FeatureArg] =
-        Space ~> (token(Flags.feature) | hideAutoCompletion("-f")) ~> (featureExamples ~ nonArgStringWithText("<feature_arg>").*)
-          .map { case (feature, args) => FeatureArg(feature +: args) }
-
-      def featureExamples: Parser[String] =
-        Space ~> token(StringBasic.examples(availableFeatures))
+        Space ~> (token(Flags.feature) | hideAutoCompletion("-f")) ~> nonArgStringWithText(s"Format: ${Flags.feature} <name> <optional_arg>").+
+          .map(args => FeatureArg(args))
 
       object Flags {
         val imageVersion = "--image-version"

--- a/src/sbt-test/sbt-conductr/sandbox-with-features/test
+++ b/src/sbt-test/sbt-conductr/sandbox-with-features/test
@@ -1,4 +1,4 @@
-> sandbox run 1.1.10 --feature visualization --feature logging
+> sandbox run 1.1.10 --feature visualization --feature monitoring v2
 
 > checkPorts
 


### PR DESCRIPTION
The `sandbox run` parser supports now the following `--feature` format:

```
sandbox run 1.1.9 --feature monitoring
sandbox run 1.1.9 --feature monitoring v2
sandbox run 1.1.9 --feature monitoring 2.1.0-RC2
```

Allowed format: `--feature <name> <optional_arg>`

`conductr-cli` will then check if the given feature is valid.