### PR TITLE
Fix compatibility issue with ConductR 1.1

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
@@ -165,7 +165,10 @@ object BundleImport {
      * @param acls list of protocol and its corresponding paths (for http) or ports (for tcp) exposed by the service endpoint
      */
     def apply(bindProtocol: String, bindPort: Int, serviceName: String, acls: RequestAcl*): Endpoint =
-      new Endpoint(bindProtocol, bindPort, None, Some(serviceName), Some(acls.toSet))
+      if (acls.flatMap(_.protocolFamilyRequestMappings).nonEmpty)
+        new Endpoint(bindProtocol, bindPort, None, Some(serviceName), Some(acls.toSet))
+      else
+        new Endpoint(bindProtocol, bindPort, Some(Set.empty), Some(serviceName), None)
 
     /**
      * Represents a service endpoint.
@@ -174,8 +177,13 @@ object BundleImport {
      * @param bindPort the port the bundle component’s application or service actually binds to; when this is 0 it will be dynamically allocated (which is the default)
      * @param acls list of protocol and its corresponding paths (for http) or ports (for tcp) exposed by the service endpoint
      */
-    def apply(bindProtocol: String, bindPort: Int, acls: RequestAcl*): Endpoint =
-      new Endpoint(bindProtocol, bindPort, None, None, Some(acls.toSet))
+    def apply(bindProtocol: String, bindPort: Int, acls: RequestAcl*): Endpoint = {
+      if (acls.flatMap(_.protocolFamilyRequestMappings).nonEmpty)
+        new Endpoint(bindProtocol, bindPort, None, None, Some(acls.toSet))
+      else
+        new Endpoint(bindProtocol, bindPort, Some(Set.empty), None, None)
+    }
+
   }
 
   /**

--- a/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
+++ b/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
@@ -19,7 +19,11 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.endpoints := Map(
-  "empty-request-acl" -> Endpoint("http", 0, "empty-request-acl", RequestAcl())
+  "empty-request-acl-with-service-name" -> Endpoint("http", 0, "service-name", RequestAcl()),
+  "empty-request-acl" -> Endpoint("http", 0, RequestAcl()),
+  "service-name" -> Endpoint("http", 0, "service-name"),
+  "protocol-and-port" -> Endpoint("tcp", 5555),
+  "protocol" -> Endpoint("tcp")
 )
 
 val checkBundleConf = taskKey[Unit]("")
@@ -41,13 +45,32 @@ checkBundleConf := {
                             |    file-system-type = "universal"
                             |    start-command    = ["acl-empty-request-mapping/bin/acl-empty-request-mapping", "-J-Xms67108864", "-J-Xmx67108864"]
                             |    endpoints = {
+                            |      "protocol-and-port" = {
+                            |        bind-protocol = "tcp"
+                            |        bind-port     = 5555
+                            |        services      = []
+                            |      },
+                            |      "empty-request-acl-with-service-name" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        service-name  = "service-name"
+                            |        services      = []
+                            |      },
+                            |      "protocol" = {
+                            |        bind-protocol = "tcp"
+                            |        bind-port     = 0
+                            |        services      = []
+                            |      },
                             |      "empty-request-acl" = {
                             |        bind-protocol = "http"
                             |        bind-port     = 0
-                            |        service-name  = "empty-request-acl"
-                            |        acls          = [
-                            |
-                            |        ]
+                            |        services      = []
+                            |      },
+                            |      "service-name" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        service-name  = "service-name"
+                            |        services      = []
                             |      }
                             |    }
                             |  }

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/build.sbt
@@ -65,9 +65,7 @@ checkBundleConf := {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
                                   |    service-name  = "backendservice"
-                                  |    acls          = [
-                                  |
-                                  |    ]
+                                  |    services= []
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"


### PR DESCRIPTION
ConductR 1.1 always expect Endpoint to declare services URI. As such, always generate empty services URI by default if no request mappings is specified.