### PR TITLE
Rename services to service-names

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -462,7 +462,7 @@ object ConductrPlugin extends AutoPlugin {
             stopSubtask(bundleNames) |
             unloadSubtask(bundleNames) |
             infoSubtask |
-            servicesSubtask |
+            serviceNamesSubtask |
             aclsSubtask |
             eventsSubtask(bundleNames) |
             logsSubtask(bundleNames)
@@ -531,10 +531,10 @@ object ConductrPlugin extends AutoPlugin {
           .!!!("Usage: conduct info")
       def infoArgs = hideAutoCompletion(commonArgs).*.map(seqToString).?
 
-      def servicesSubtask: Parser[ConductSubtaskSuccess] =
-        token("services" ~> servicesArgs)
-          .map { case args => ConductSubtaskSuccess("services", optionalArgs(args)) }
-          .!!!("Usage: conduct services")
+      def serviceNamesSubtask: Parser[ConductSubtaskSuccess] =
+        token("service-names" ~> servicesArgs)
+          .map { case args => ConductSubtaskSuccess("service-names", optionalArgs(args)) }
+          .!!!("Usage: conduct service-names")
       def servicesArgs = hideAutoCompletion(commonArgs).*.map(seqToString).?
 
       def aclsSubtask: Parser[ConductSubtaskSuccess] =

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/test
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/test
@@ -5,8 +5,8 @@ $ sleep 5000
 # conduct info
 > conduct info
 
-# conduct services
-> conduct services
+# conduct service-names
+> conduct service-names
 
 # conduct acls http
 > conduct acls http


### PR DESCRIPTION
The `conduct` sub command `services` has been renamed to `service-names` in the lastest conductr-cli. This PR also applies this change to `sbt-conductr`.