### PR TITLE
Validates resident memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ javaOptions in Universal := Seq(
 )
 
 BundleKeys.nrOfCpus := 0.1
-BundleKeys.memory := 128.MiB
+BundleKeys.memory := 384.MiB
 BundleKeys.diskSpace := 50.MB
 ```
 
-The `javaOptions` values declare the maximum and minimum heap size for your application respectively. Profiling your application under load will help you determine an optimal heap size. We recommend declaring the `BundleKeys.memory` value to be approximately twice that of the heap size. `BundleKeys.memory` represents the *resident* memory size of your application, which includes the heap, thread stacks, code caches, the code itself and so forth. On Unix, use the `top` command and observe the resident memory column (`RES`) with your application under load.
+The `javaOptions` values declare the maximum and minimum heap size for your application respectively. Profiling your application under load will help you determine an optimal heap size. We recommend declaring the `BundleKeys.memory` value to be at least 384 MiB. `BundleKeys.memory` represents the *resident* memory size of your application, which includes the heap, thread stacks, code caches, the code itself and so forth. On Unix, use the `top` command and observe the resident memory column (`RES`) with your application under load.
 
-`BundleKeys.memory` is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production.
+`BundleKeys.memory` is used for locating machines with enough resources to run your application, and so it is particularly important to size it before you go to production. Not setting this value correctly can lead to your bundle being killed by the operating system.
 
 ### Bundle configuration
 
@@ -399,6 +399,7 @@ enableAcls            | Acls can be declared on an endpoint if this setting is '
 endpoints             | Declares endpoints. The default is Map("web" -> Endpoint("http", 0, Set.empty)). The endpoint key is used to form a set of environment variables for your components, e.g. for the endpoint key "web" ConductR creates the environment variable `WEB_BIND_PORT`.
 executableScriptPath  | The relative path of the executableScript within the bundle.
 memory                | The amount of resident memory required to run the bundle. Use the Unix `top` command to determine this value by observing the `RES` and rounding up to the nearest 10MiB.
+minMemoryCheckValue   | The minimum value for the `memory` setting that is checked when creating a bundle. Defaults to 384MiB.
 nrOfCpus              | The minimum number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). This value is considered when starting a bundle on a node. If the specified CPUs exceeds the available CPUs on a node, then this node is not considered for scaling the bundle. Once running, the application is not restricted to the given value and tries to use all available CPUs on the node. Required.
 overrideEndpoints     | Overrides the endpoints settings key with new endpoints. This task should be used if the endpoints need to be specified programmatically. The default is None.
 roles                 | The types of node in the cluster that this bundle can be deployed to. Defaults to "web".

--- a/sbt-conductr-tester/bundle/build.sbt
+++ b/sbt-conductr-tester/bundle/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.11.8"
 
 // ConductR
 BundleKeys.nrOfCpus := 0.1
-BundleKeys.memory := 64.MiB
+BundleKeys.memory := 384.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.endpoints := Map("web" -> Endpoint("http", 0, Set(URI("http://:9001"))))
 

--- a/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
@@ -289,6 +289,11 @@ object BundleImport {
       "The amount of resident memory required to run the bundle. Use the Unix `top` command to determine this value by observing the `RES` and rounding up to the nearest 10MiB. Required."
     )
 
+    val minMemoryCheckValue = SettingKey[Bytes](
+      "bundle-min-memory-check-value",
+      "The minimum value for the `memory` setting that is checked when creating a bundle. Defaults to 384MiB."
+    )
+
     val nrOfCpus = SettingKey[Double](
       "bundle-nr-of-cpus",
       "The minimum number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). This value is considered when starting a bundle on a node. If the specified CPUs exceeds the available CPUs on a node, then this node is not considered for scaling the bundle. Once running, the application is not restricted to the given value and tries to use all available CPUs on the node. Required."

--- a/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
+++ b/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
@@ -16,6 +16,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.endpoints := Map(

--- a/src/sbt-test/bundle-plugin/acl-no-service-name/build.sbt
+++ b/src/sbt-test/bundle-plugin/acl-no-service-name/build.sbt
@@ -16,6 +16,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.endpoints := Map(

--- a/src/sbt-test/bundle-plugin/basic/build.sbt
+++ b/src/sbt-test/bundle-plugin/basic/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))

--- a/src/sbt-test/bundle-plugin/bundle-config/build.sbt
+++ b/src/sbt-test/bundle-plugin/bundle-config/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.configurationName := "backend"

--- a/src/sbt-test/bundle-plugin/checks/build.sbt
+++ b/src/sbt-test/bundle-plugin/checks/build.sbt
@@ -16,6 +16,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.checkInitialDelay := 1400.milliseconds
 BundleKeys.checks := Seq(uri("$CHECKS_HOST?retry-count=5&retry-delay=3"))

--- a/src/sbt-test/bundle-plugin/overlays/build.sbt
+++ b/src/sbt-test/bundle-plugin/overlays/build.sbt
@@ -13,6 +13,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.nrOfCpus in BundleConfiguration := 11.0

--- a/src/sbt-test/bundle-plugin/validation-acl-and-service/build.sbt
+++ b/src/sbt-test/bundle-plugin/validation-acl-and-service/build.sbt
@@ -17,6 +17,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 BundleKeys.endpoints += "ping-service" -> Endpoint("http", 0, Some(Set(URI("http://:9001/ping-service"))), Some("ping-service"),

--- a/src/sbt-test/bundle-plugin/validation-min-memory/build.sbt
+++ b/src/sbt-test/bundle-plugin/validation-min-memory/build.sbt
@@ -14,7 +14,7 @@ javaOptions in Universal := Seq(
 )
 
 BundleKeys.nrOfCpus := 0.1
-BundleKeys.memory := 64.MiB
+BundleKeys.memory := 32.MiB
 BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 

--- a/src/sbt-test/bundle-plugin/validation-min-memory/project/build.properties
+++ b/src/sbt-test/bundle-plugin/validation-min-memory/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/src/sbt-test/bundle-plugin/validation-min-memory/project/plugins.sbt
+++ b/src/sbt-test/bundle-plugin/validation-min-memory/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/bundle-plugin/validation-min-memory/test
+++ b/src/sbt-test/bundle-plugin/validation-min-memory/test
@@ -1,0 +1,2 @@
+-> bundle:dist
+> checkBundleConfNotGenerated

--- a/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service/build.sbt
@@ -16,7 +16,8 @@ lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
       "-J-Xmx268435456"
     ),
     BundleKeys.conductrTargetVersion := ConductrVersion.V2,
-    BundleKeys.memory := 256.MiB
+    BundleKeys.memory := 256.MiB,
+    BundleKeys.minMemoryCheckValue := 256.MiB
   )
 
 lazy val `play-service` = (project in file("play-service"))
@@ -28,7 +29,8 @@ lazy val `play-service` = (project in file("play-service"))
     ),
     BundleKeys.conductrTargetVersion := ConductrVersion.V2,
     routesGenerator := InjectedRoutesGenerator,
-    BundleKeys.memory := 64.MiB
+    BundleKeys.memory := 64.MiB,
+    BundleKeys.minMemoryCheckValue := 64.MiB
   )
 
 // Test assertions

--- a/src/sbt-test/play-bundle-plugin/custom-config/build.sbt
+++ b/src/sbt-test/play-bundle-plugin/custom-config/build.sbt
@@ -9,6 +9,7 @@ version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 
 val checkBundleDist = taskKey[Unit]("check-bundle-dist-contents")
 checkBundleDist := {

--- a/src/sbt-test/sbt-conductr/conduct-common-args/build.sbt
+++ b/src/sbt-test/sbt-conductr/conduct-common-args/build.sbt
@@ -16,4 +16,5 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 10.MiB
+BundleKeys.minMemoryCheckValue := 10.MiB
 BundleKeys.diskSpace := 5.MB

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/build.sbt
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/build.sbt
@@ -16,6 +16,7 @@ javaOptions in Universal := Seq(
 
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 10.MiB
+BundleKeys.minMemoryCheckValue := 10.MiB
 BundleKeys.diskSpace := 5.MB
 
 val verifyConductLoad = taskKey[Unit]("")

--- a/src/sbt-test/sbt-conductr/sandbox-all-args/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 val checkConductrIsStopped = taskKey[Unit]("")

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-basic/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http://:9001/other-service"))))
 

--- a/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/build.sbt
@@ -16,6 +16,7 @@ lazy val frontend = (project in file("modules/frontend"))
     ),
     BundleKeys.nrOfCpus := 0.1,
     BundleKeys.memory := 64.MiB,
+    BundleKeys.minMemoryCheckValue := 64.MiB,
     BundleKeys.diskSpace := 50.MiB,
     BundleKeys.roles := Set("frontend"),
     BundleKeys.endpoints := Map("frontend" -> Endpoint("http", services = Set(URI("http://:9000"))))
@@ -31,6 +32,7 @@ lazy val backend = (project in file("modules/backend"))
     ),
     BundleKeys.nrOfCpus := 0.1,
     BundleKeys.memory := 128.MiB,
+    BundleKeys.minMemoryCheckValue := 128.MiB,
     BundleKeys.diskSpace := 50.MiB,
     BundleKeys.roles := Set("backend"),
     BundleKeys.endpoints := Map(

--- a/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-override-endpoints/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.overrideEndpoints in Bundle := Some(Map("other" -> Endpoint("http", services = Set(URI("http://:9001")))))
 

--- a/src/sbt-test/sbt-conductr/sandbox-scaling/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-scaling/build.sbt
@@ -13,6 +13,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 def resolveRunningContainers = """docker ps --quiet --filter name=cond""".lines_!

--- a/src/sbt-test/sbt-conductr/sandbox-with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-with-features/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 /**

--- a/src/sbt-test/sbt-conductr/sandbox-with-rp-license/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-with-rp-license/build.sbt
@@ -15,6 +15,7 @@ javaOptions in Universal := Seq(
 // ConductR bundle keys
 BundleKeys.nrOfCpus := 0.1
 BundleKeys.memory := 64.MiB
+BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
 val checkConductrIsStopped = taskKey[Unit]("")


### PR DESCRIPTION
This memory checking verification should help users avoid specifying resident memory values that are too low at runtime.