### PR TITLE
add support for recently added `sandbox ps` command

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -212,6 +212,7 @@ object ConductrPlugin extends AutoPlugin {
       case SandboxHelp                 => sandboxHelp()
       case SandboxSubtaskHelp(command) => sandboxSubHelp(command)
       case SandboxRunSubtask(args)     => Project.extract(state.value).runTask(sandboxRunTaskInternal, state.value.put(SandboxRunArgsAttrKey, args))
+      case SandboxPsSubtask            => sandboxPs()
       case SandboxStopSubtask          => sandboxStop()
       case SandboxVersionSubtask       => sandboxVersion()
     }
@@ -300,6 +301,12 @@ object ConductrPlugin extends AutoPlugin {
   }
 
   /**
+   * Executes the `sandbox ps` command of the conductr-cli
+   */
+  def sandboxPs(): Unit =
+    Process(Seq("sandbox", "ps")).!
+
+  /**
    * Executes the `sandbox stop` command of the conductr-cli
    */
   def sandboxStop(): Unit =
@@ -361,6 +368,7 @@ object ConductrPlugin extends AutoPlugin {
         case _ =>
           (Space ~> (
             helpSubtask |
+            psSubtask |
             runSubtask |
             stopSubtask |
             versionSubtask
@@ -394,6 +402,11 @@ object ConductrPlugin extends AutoPlugin {
         }
       def isRunArg(arg: String, flag: String): Boolean =
         arg.startsWith(flag)
+
+      def psSubtask: Parser[SandboxPsSubtask.type] =
+        token("ps")
+          .map { case _ => SandboxPsSubtask }
+          .!!!("Usage: sandbox ps")
 
       def stopSubtask: Parser[SandboxStopSubtask.type] =
         token("stop")
@@ -695,6 +708,7 @@ object ConductrPlugin extends AutoPlugin {
   private trait SubtaskSuccess
   private sealed trait SandboxSubtask
   private case class SandboxRunSubtask(args: SandboxRunArgs) extends SandboxSubtask with SubtaskSuccess
+  private object SandboxPsSubtask extends SandboxSubtask with SubtaskSuccess
   private object SandboxStopSubtask extends SandboxSubtask with SubtaskSuccess
   private object SandboxVersionSubtask extends SandboxSubtask with SubtaskSuccess
   private case object SandboxHelp extends SandboxSubtask


### PR DESCRIPTION
Adds `sandbox ps` command to `sbt-conductr` to wrap @fsat's recent commit to `conductr-cli`