### PR TITLE
Add Lightbend credentials to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ before_script:
   - "sekexe/run docker -d -H tcp://0.0.0.0:2375 &"
   - "while ! docker -H tcp://$HOST_IP:2375 info &> /dev/null ; do sleep 1; done"
 
-script: sbt scripted
+script:
+  - ./bin/create-credentials.sh
+  - sbt scripted

--- a/bin/create-credentials.sh
+++ b/bin/create-credentials.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+mkdir ~/.lightbend
+echo "realm = Bintray
+host = dl.bintray.com
+user = e5f80053-61c0-4457-b2e8-05d5ae5d226d@lightbend
+password = cffe8178358500a841d57bc03a35da20d3b7ac98
+" > ~/.lightbend/commercial.credentials


### PR DESCRIPTION
Adding Lightbend credentials to Bintray so that the sbt scripted tests on travis can download the reactive maps bundles from Bintray.