### PR TITLE
`withFlag` now uses an equal sign if the argument begins with a dash,…

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -837,7 +837,7 @@ object ConductrPlugin extends AutoPlugin {
 
     implicit class TraversableOps[T](val self: Traversable[T]) extends AnyVal {
       def withFlag(flag: String): Seq[String] =
-        self.flatMap { e =>
+        self.toSeq.flatMap { e =>
           val s = e.toString
 
           // python's argparse can't parse "--somearg" "-Dsomevalue", must be specified as "--somearg=-Dsomevalue"
@@ -847,7 +847,7 @@ object ConductrPlugin extends AutoPlugin {
             Seq(s"$flag=$s")
           else
             Seq(flag, s)
-        }.toSeq
+        }
     }
   }
 }

--- a/src/test/scala/com/lightbend/conductr/sbt/ProcessConvertersSpec.scala
+++ b/src/test/scala/com/lightbend/conductr/sbt/ProcessConvertersSpec.scala
@@ -17,6 +17,17 @@ class ProcessConvertersSpec extends WordSpec with Matchers {
       Seq("-Dmy.greeting=hello world").withFlag("--args") shouldBe Seq("--args=-Dmy.greeting=hello world")
     }
 
+    "format typical arguments from Set correctly" in {
+      Set("false", "true").withFlag("--enable-feature") shouldBe Seq("--enable-feature", "false", "--enable-feature", "true")
+
+      Set("hello world", "hi").withFlag("--greeting") shouldBe Seq("--greeting", "hello world", "--greeting", "hi")
+    }
+
+    "format dash (-) arguments from Set correctly" in {
+      Set("false", "-Denable=false").withFlag("--arg") shouldBe Seq("--arg", "false", "--arg=-Denable=false")
+      Set("-Dmy.greeting=hello world").withFlag("--args") shouldBe Seq("--args=-Dmy.greeting=hello world")
+    }
+
     "format typical arguments from Option correctly" in {
       None.withFlag("--arg") shouldBe Seq()
 

--- a/src/test/scala/com/lightbend/conductr/sbt/ProcessConvertersSpec.scala
+++ b/src/test/scala/com/lightbend/conductr/sbt/ProcessConvertersSpec.scala
@@ -1,0 +1,30 @@
+package com.lightbend.conductr.sbt
+
+import org.scalatest.{ Matchers, WordSpec }
+
+import ConductrPlugin.ProcessConverters._
+
+class ProcessConvertersSpec extends WordSpec with Matchers {
+  "ProcessConverters" should {
+    "format typical arguments from Seq correctly" in {
+      Seq("false", "true").withFlag("--enable-feature") shouldBe Seq("--enable-feature", "false", "--enable-feature", "true")
+
+      Seq("hello world", "hi").withFlag("--greeting") shouldBe Seq("--greeting", "hello world", "--greeting", "hi")
+    }
+
+    "format dash (-) arguments from Seq correctly" in {
+      Seq("false", "-Denable=false").withFlag("--arg") shouldBe Seq("--arg", "false", "--arg=-Denable=false")
+      Seq("-Dmy.greeting=hello world").withFlag("--args") shouldBe Seq("--args=-Dmy.greeting=hello world")
+    }
+
+    "format typical arguments from Option correctly" in {
+      None.withFlag("--arg") shouldBe Seq()
+
+      Some("false").withFlag("--enable-feature") shouldBe Seq("--enable-feature", "false")
+    }
+
+    "format dash (-) arguments from Option correctly" in {
+      Some("-Denable=false").withFlag("--arg") shouldBe Seq("--arg=-Denable=false")
+    }
+  }
+}


### PR DESCRIPTION
This PR changes slightly how `withFlag` builds arguments. Python's argparse, which sandbox uses, can't handle a command line such as `sandbox run 2.0.0 --env-core -Dsome.property=true`. Instead, this syntax needs to be used: `sandbox run 2.0.0 --env-core=-Dsome.property=true`.

This PR adjusts the `withFlag` method to use this equals format if given a property that starts with a dash, thereby allowing these properties to be passed to the sandbox correctly.

See http://bugs.python.org/issue9334