### PR TITLE
Fixes `cassandra-configuration` command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Property                     | Description
 -----------------------------|------------
 bundle:dist                  | Produce a ConductR bundle for all projects that have the native packager enabled
 configuration:dist           | Produce a bundle configuration for all projects that have the native packager enabled
-cassandra:configuration:dist | Produce one cassandra bundle configuration in the root target directory
+cassandra-configuration:dist | Produce one cassandra bundle configuration in the root target directory
 sandbox help                 | Get usage information of the sandbox command
 sandbox run                  | Start a local ConductR sandbox
 sandbox stop                 | Stop the local ConductR sandbox


### PR DESCRIPTION
There's a typo in the `cassandra-configuration:dist` command.

```
> cassandra:configuration:dist
[error] Expected '::'
[error] cassandra:configuration:dist
[error]                         ^
> cassandra-configuration:dist
[info] Cassandra bundle configuration has been created: ...
...
[success] Total time: 4 s, completed Feb 16, 2017 2:17:09 PM
```