### PR TITLE
Export custom cassandra configuration

### DIFF
--- a/src/main/resources/bundle-configuration/cassandra-acls/runtime-config.sh
+++ b/src/main/resources/bundle-configuration/cassandra-acls/runtime-config.sh
@@ -1,3 +1,3 @@
 # Demonstrate providing an entirely new configuration directory
 CURRENT_PATH=`dirname "$0"`
-export $CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf
+export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf

--- a/src/main/resources/bundle-configuration/cassandra-services/runtime-config.sh
+++ b/src/main/resources/bundle-configuration/cassandra-services/runtime-config.sh
@@ -1,3 +1,3 @@
 # Demonstrate providing an entirely new configuration directory
 CURRENT_PATH=`dirname "$0"`
-export $CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf
+export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
@@ -61,7 +61,7 @@ checkCassandraConf := {
   val runtimeConfigContent = IO.read(cassandraConfigurationDir / "runtime-config.sh").indent
   val expectedRuntimeConfigContent = """|# Demonstrate providing an entirely new configuration directory
                                         |CURRENT_PATH=`dirname "$0"`
-                                        |export $CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
+                                        |export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
   runtimeConfigContent should include (expectedRuntimeConfigContent)
 
   val cassandraYaml = cassandraConfigurationDir / "cassandra-conf" / "cassandra.yaml"

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
@@ -51,7 +51,7 @@ checkCassandraConf := {
   val runtimeConfigContent = IO.read(cassandraConfigurationDir / "runtime-config.sh").indent
   val expectedRuntimeConfigContent = """|# Demonstrate providing an entirely new configuration directory
                                         |CURRENT_PATH=`dirname "$0"`
-                                        |export $CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
+                                        |export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
   runtimeConfigContent should include (expectedRuntimeConfigContent)
 
   val cassandraYaml = cassandraConfigurationDir / "cassandra-conf" / "cassandra.yaml"


### PR DESCRIPTION
The custom Cassandra configuration inside the `cassandra-conf` directory was not correctly included because the `export` command had a bug.

```
4036200951222982399/463d43f142f64d464b50b38a7790fc41635d988f00188a9311b0634cd3d7211d/cassandra-configuration/runtime-config.sh: line 3: export: `=/Users/mj/.conductr/images/tmp/conductr-agent/192.168.10.1/bundles/4f71ca2fc8760ddabadfd8bdcdfbfbcc-463d43f142f64d464b50b38a7790fc41/execution-0-4036200951222982399/cassandra-conf': not a valid identifier
```

Now this custom Cassandra configuration is used.