### PR TITLE
Setting the correct cassandra configuration

### DIFF
--- a/src/main/resources/bundle-configuration/cassandra-acls/runtime-config.sh
+++ b/src/main/resources/bundle-configuration/cassandra-acls/runtime-config.sh
@@ -1,3 +1,3 @@
-# Demonstrate providing an entirely new configuration directory
-CURRENT_PATH=`dirname "$0"`
-export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf
+# Setting Cassandra configuration directory to the bundle configuration directory
+BUNDLE_CONFIG_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd )"
+export CASSANDRA_CONF=$BUNDLE_CONFIG_DIR/cassandra-conf

--- a/src/main/resources/bundle-configuration/cassandra-services/runtime-config.sh
+++ b/src/main/resources/bundle-configuration/cassandra-services/runtime-config.sh
@@ -1,3 +1,3 @@
-# Demonstrate providing an entirely new configuration directory
-CURRENT_PATH=`dirname "$0"`
-export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf
+# Setting Cassandra configuration directory to the bundle configuration directory
+BUNDLE_CONFIG_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd )"
+export CASSANDRA_CONF=$BUNDLE_CONFIG_DIR/cassandra-conf

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
@@ -59,9 +59,9 @@ checkCassandraConf := {
   bundleConfContent should include (expectedBundleConfContent)
 
   val runtimeConfigContent = IO.read(cassandraConfigurationDir / "runtime-config.sh").indent
-  val expectedRuntimeConfigContent = """|# Demonstrate providing an entirely new configuration directory
-                                        |CURRENT_PATH=`dirname "$0"`
-                                        |export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
+  val expectedRuntimeConfigContent = """|# Setting Cassandra configuration directory to the bundle configuration directory
+                                        |BUNDLE_CONFIG_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd )"
+                                        |export CASSANDRA_CONF=$BUNDLE_CONFIG_DIR/cassandra-conf""".stripMargin.indent
   runtimeConfigContent should include (expectedRuntimeConfigContent)
 
   val cassandraYaml = cassandraConfigurationDir / "cassandra-conf" / "cassandra.yaml"

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
@@ -49,9 +49,9 @@ checkCassandraConf := {
   bundleConfContent should include (expectedBundleConfContent)
 
   val runtimeConfigContent = IO.read(cassandraConfigurationDir / "runtime-config.sh").indent
-  val expectedRuntimeConfigContent = """|# Demonstrate providing an entirely new configuration directory
-                                        |CURRENT_PATH=`dirname "$0"`
-                                        |export CASSANDRA_CONF=$CURRENT_PATH/cassandra-conf""".stripMargin.indent
+  val expectedRuntimeConfigContent = """|# Setting Cassandra configuration directory to the bundle configuration directory
+                                        |BUNDLE_CONFIG_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd )"
+                                        |export CASSANDRA_CONF=$BUNDLE_CONFIG_DIR/cassandra-conf""".stripMargin.indent
   runtimeConfigContent should include (expectedRuntimeConfigContent)
 
   val cassandraYaml = cassandraConfigurationDir / "cassandra-conf" / "cassandra.yaml"


### PR DESCRIPTION
Setting Cassandra configuration directory to the bundle configuration directory.

Fixes https://github.com/typesafehub/sbt-conductr/issues/202.