### PR TITLE
WIP - DO NOT MERGE - Adds fat jars to bundle creation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ unmanagedSourceDirectories in Compile := List((scalaSource in Compile).value)
 unmanagedSourceDirectories in Test := List((scalaSource in Test).value)
 
 // Plugin dependencies
+addSbtPlugin(Library.assembly)
 addSbtPlugin(Library.nativePackager)
 
 // Library dependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@
 import sbt._
 
 object Version {
+  val assembly          = "0.14.4"
   val nativePackager    = "1.0.6"
   val play              = "2.3.10" // Using Play 2.3 to use Scala 2.10 library
   val scalaTest         = "2.2.6"
@@ -12,6 +13,7 @@ object Version {
 }
 
 object Library {
+  val assembly               = "com.eed3si9n"          % "sbt-assembly"                 % Version.assembly
   val nativePackager         = "com.typesafe.sbt"      %  "sbt-native-packager"         % Version.nativePackager
   val playJson               = "com.typesafe.play"     %% "play-json"                   % Version.play
   val scalaTest              = "org.scalatest"         %% "scalatest"                   % Version.scalaTest % "test"

--- a/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
@@ -8,6 +8,7 @@ import sbt._
 import sbt.Keys._
 import com.typesafe.sbt.SbtNativePackager
 import com.typesafe.sbt.packager.universal.Archives
+import sbtassembly.AssemblyPlugin
 import SbtNativePackager.Universal
 import java.io.{ BufferedInputStream, FileInputStream }
 import java.security.MessageDigest
@@ -17,6 +18,7 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 
 object BundlePlugin extends AutoPlugin {
+  import AssemblyPlugin.autoImport._
   import BundleImport._
   import BundleKeys._
   import ByteConversions._
@@ -24,7 +26,7 @@ object BundlePlugin extends AutoPlugin {
 
   val autoImport = BundleImport
 
-  override def requires = SbtNativePackager
+  override def requires = AssemblyPlugin && SbtNativePackager
 
   override def trigger = AllRequirements
 
@@ -43,9 +45,14 @@ object BundlePlugin extends AutoPlugin {
         minMemoryCheckValue := 384.MiB,
         projectTarget := target.value,
         roles := Set("web"),
+        NativePackagerKeys.scriptClasspathOrdering := {
+          val assemblyFile = assembly.value
+          Seq(assemblyFile -> (file("lib") / assemblyFile.getName).getPath)
+        },
         system := (normalizedName in Bundle).value,
         systemVersion := (compatibilityVersion in Bundle).value,
-        startCommand := Seq((executableScriptPath in Bundle).value) ++ (javaOptions in Bundle).value
+        startCommand := Seq((executableScriptPath in Bundle).value) ++ (javaOptions in Bundle).value,
+        test in assembly := {}
       )
 
   override def projectConfigurations: Seq[Configuration] =


### PR DESCRIPTION
I'm not sure about seeing this merged. The general idea though is that we create a fat jar for our bundles so that they are `ps` friendly. We use sbt-assembly in conjunction with the native packager.

The problem is that Play (at least), has merge conflicts. This should indeed be fixed separately as they could be bugs. For example:

```
[error] (*:assembly) deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/io.netty/netty-buffer/jars/netty-buffer-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-common/jars/netty-common-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-codec-http/jars/netty-codec-http-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-codec/jars/netty-codec-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-transport/jars/netty-transport-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-handler/jars/netty-handler-4.0.42.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/huntc/.ivy2/cache/io.netty/netty-transport-native-epoll/jars/netty-transport-native-epoll-4.0.42.Final-linux-x86_64.jar:META-INF/io.netty.versions.properties
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/Log.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/Log.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/LogConfigurationException.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/LogConfigurationException.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/LogFactory.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/LogFactory.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/impl/NoOpLog.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/impl/NoOpLog.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/impl/SimpleLog$1.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/impl/SimpleLog$1.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/org.slf4j/jcl-over-slf4j/jars/jcl-over-slf4j-1.7.21.jar:org/apache/commons/logging/impl/SimpleLog.class
[error] /Users/huntc/.ivy2/cache/commons-logging/commons-logging/jars/commons-logging-1.2.jar:org/apache/commons/logging/impl/SimpleLog.class
[error] deduplicate: different file contents found in the following:
[error] /Users/huntc/.ivy2/cache/com.typesafe.conductr/play25-conductr-bundle-lib_2.11/jars/play25-conductr-bundle-lib_2.11-1.6.1.jar:play/reference-overrides.conf
[error] /Users/huntc/.ivy2/cache/com.typesafe.play/play_2.11/jars/play_2.11-2.5.12.jar:play/reference-overrides.conf
```

cc. @gmethvin 