### PR TITLE
Rework subprocess execution to check return code when using `.!` and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - sudo apt-get -qqy update
   - sudo apt-get -qqy install python3-setuptools
   - sudo easy_install3 -U pip
-  - pip3 install --user conductr-cli
+  - pip3 install --user git+git://github.com/typesafehub/conductr-cli.git@master
   # Ensure that our sandbox interfaces are prepared
   - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.255 up
   - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.255 up
@@ -23,6 +23,8 @@ install:
   # Warm up some caches so that our tests don't timeout
   - sandbox run 2.0.0 -f visualization -f monitoring > /dev/null
   - conduct load -q cassandra
+  - conduct load -q cinnamon-grafana-docker
+  - conduct load -q eslite
   - conduct load -q reactive-maps-backend-region
   - conduct load -q reactive-maps-backend-summary
   # Tests go faster if we do this... less interactions with bintray etc.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ sbt-conductr is a sbt plugin that provides commands in sbt to:
 * [Command Overview](#command-overview)
 * [ConductR Plugin](#conductr-plugin)
 * [Bundle Plugins](#bundle-plugins)
+* [Developers](#developers)
 
 ## Prerequisite
 
@@ -411,6 +412,32 @@ roles                 | The types of node in the cluster that this bundle can be
 startCommand          | Command line args required to start the component. Paths are expressed relative to the component's bin folder. The default is to use the bash script in the bin folder. <br/> Example JVM component: </br> `BundleKeys.startCommand += "-Dakka.cluster.roles.1=frontend"` </br> Example Docker component (should additional args be required): </br> `BundleKeys.startCommand += "dockerArgs -v /var/lib/postgresql/data:/var/lib/postgresql/data"` (this adds arguments to `docker run`). Note that memory heap is controlled by the BundleKeys.memory key and heap flags should not be passed here.
 system                | A logical name that can be used to associate multiple bundles with each other. This could be an application or service association and should include a version e.g. myapp-1.0.0. Defaults to the package name.
 systemVersion         | A version to associate with a system. This setting defaults to the value of compatibilityVersion.
+
+## Developers
+
+#### Running unit tests
+
+```
+# Run all tests
+sbt test
+
+# Run a single test
+sbt test-only com.lightbend.conductr.sbt.BundlePluginSpec
+```
+
+#### Running scripted tests
+
+```
+# bash - Run all tests
+sbt scripted
+
+# bash - Run a single test
+sbt "scripted sbt-conductr/conduct-common-args"
+
+# sbt - Interactive test output
+set scriptedBufferLog := false
+scripted sbt-conductr/conduct-common-args
+```
 
 
 &copy; Lightbend Inc., 2014-2016

--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRImport.scala
@@ -34,7 +34,6 @@ object ConductrImport {
   )
 
   object ConductrKeys {
-
     val hasRpLicense = SettingKey[Boolean](
       "conductr-has-rp-license",
       "Checks that the project has a reactive platform license"

--- a/src/sbt-test/sbt-conductr/conduct-common-args/test
+++ b/src/sbt-test/sbt-conductr/conduct-common-args/test
@@ -2,19 +2,30 @@
 > conduct
 > conduct --help
 
-# conduct sub help
+# conduct subs
+> conduct acls
+> conduct acls -h http
+> conduct acls -h tcp
+> conduct events
+> conduct events -h
+> conduct events --help
+> conduct info -h
+> conduct info --help
 > conduct load
 > conduct load -h
 > conduct load --help
-> conduct info
-> conduct info -h
-> conduct info --help
 > conduct run
-> conduct run -h
 > conduct run --help
-
-# conduct version
+> conduct service-names -h
+> conduct service-names --help
+> conduct stop
+> conduct stop -h
+> conduct stop --help
+> conduct unload -h
+> conduct unload --help
 > conduct version
+> conduct version -h
+> conduct version --help
 
 # common opts
-> conduct info -q -v --long-ids --api-version 2 --local-connection --ip 1.1.1.1 --port 9999 --settings-dir /some/path --custom-settings-file /some/path --custom-plugins-dir /some/path
+> conduct info -h -q -v --long-ids --api-version 2 --local-connection --ip 1.1.1.1 --port 9999 --settings-dir /some/path --custom-settings-file /some/path --custom-plugins-dir /some/path

--- a/src/sbt-test/sbt-conductr/sandbox-all-args/test
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/test
@@ -4,15 +4,24 @@
 > sandbox --help
 
 # sandbox sub help
-> sandbox run
+> sandbox run -h
+> sandbox run --help
+> sandbox stop -h
+> sandbox stop --help
+> sandbox restart -h
+> sandbox restart --help
+> sandbox ps -h
+> sandbox ps --help
+> sandbox logs -h
+> sandbox logs --help
 
 # sandbox version
 > sandbox version
 
 # sandbox long args
-> sandbox run 2.0.0 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
+> sandbox run 2.0.0 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role web --conductr-role backend db --feature visualization --feature logging
 > sandbox stop
 
 # sandbox short args
-> sandbox run 2.0.0 -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r frontend -r backend db -f visualization -f logging
+> sandbox run 2.0.0 --no-default-features -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r web -r backend db -f visualization -f lite-logging
 > sandbox stop

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
@@ -1,10 +1,10 @@
-> sandbox run 2.0.0 --nr-of-containers 3
+> sandbox run 2.0.0 --no-default-features --nr-of-instances 3:3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> sandbox run 2.0.0 --nr-of-containers 4 --conductr-role new-role --conductr-role other-role
+> sandbox run 2.0.0 --no-default-features --nr-of-instances 4:4 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/sbt-conductr/sandbox-end-to-end/test
+++ b/src/sbt-test/sbt-conductr/sandbox-end-to-end/test
@@ -1,4 +1,4 @@
-> sandbox run 2.0.0 --nr-of-instances 3:3 --feature visualization --feature monitoring v2 --port 1111 --port 2222 --port 2551
+> sandbox run 2.0.0 --nr-of-instances 3:3 --feature visualization --feature monitoring --port 1111 --port 2222 --port 2551
 
 # sandbox checks
 > checkInstances3


### PR DESCRIPTION
This will ensure SBT commands indicate an error has occurred if one has. Fixes #207.

I think this is reasonable behavior, as a user I would expect SBT commands to indicate an error has occurred if the commands are reliant on a subprocess exiting successfully.

Manual test:

```
[eslite]> sandbox run
The version of ConductR need to be set.
Please visit https://www.lightbend.com/product/conductr/developer to obtain the current version information.
[error] ({.}/*:sandboxRunTaskInternal) java.lang.IllegalArgumentException: requirement failed: sandbox exited with 1
[error] ({.}/*:sandbox) java.lang.IllegalArgumentException: requirement failed: sandbox exited with 1
[error] Total time: 2 s, completed Feb 21, 2017 10:33:25 AM
```