### PR TITLE
Use conductrTargetVersion V2_0 as default (2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.5")
 
 sbt-conductr contains several sbt auto plugins. The following table provides an overview of the auto plugins and when they get triggered.
 
-| Plugin                | Description                                                                    | Scope   | Trigger
-|-----------------------|--------------------------------------------------------------------------------|---------|--------- 
-| ConductrPlugin        | Uses the conductr-cli commands to manage a ConductR cluster                    | Global  | Always enabled
-| BundlePlugin          | Produce a bundle and bundle configuration for a JavaAppPackaing application.   | Project | JavaAppPackaging
-| PlayBundlePlugin      | Produce a bundle and bundle configuration for a Play application.              | Project | Play && BundlePlugin
+| Plugin                | Description                                                                              | Scope   | Trigger
+|-----------------------|------------------------------------------------------------------------------------------|---------|--------- 
+| ConductrPlugin        | Uses the conductr-cli commands to manage a ConductR cluster                              | Global  | Always enabled
+| BundlePlugin          | Produce a bundle and bundle configuration for a JavaAppPackaging application.            | Project | JavaAppPackaging
+| PlayBundlePlugin      | Produce a bundle and bundle configuration for a Play application.                        | Project | Play && BundlePlugin
 | LagomPlayBundlePlugin | Produce a bundle and bundle configuration for a Play application inside a Lagom project. | Project | LagomPlay && BundlePlugin
-| LagomBundlePlugin     | Produce a bundle and bundle configuration for a Lagom service.                 | Project | LagomJava && BundlePlugin
-| LagomConductrPlugin   | Adds Lagom concerns to ConductrPlugin                                          | Global  | ConductrPlugin && LagomBundlePlugin
+| LagomBundlePlugin     | Produce a bundle and bundle configuration for a Lagom service.                           | Project | LagomJava && BundlePlugin
+| LagomConductrPlugin   | Adds Lagom concerns to ConductrPlugin                                                    | Global  | ConductrPlugin && LagomBundlePlugin
 
 The `ConductRPlugin` is enabled as soon as `sbt-conductr` has been added to the project. The `BundlePlugin` is triggered for each project that enables a native packager plugin in the `build.sbt`, e.g.:
 
@@ -390,10 +390,10 @@ bundleType            | The type of configuration that this bundling relates to.
 checkInitialDelay     | Initial delay before the check uris are triggered. The `FiniteDuration` value gets rounded up to full seconds. Default is 3 seconds.
 checks                | Declares uris to check to signal to ConductR that the bundle components have started for situations where component doesn't do that. For example `Seq(uri("$WEB_HOST"))` will check that a endpoint named "web" will be checked given its host environment var. Once that URL becomes available then ConductR will be signalled that the bundle is ready. Note that a `docker+` prefix should be used when waiting on Docker components so that the Docker build event is waited on e.g. `Seq(uri("docker+$WEB_HOST"))`<br/>Optional params are: 'retry-count': Number of retries, 'retry-delay': Delay in seconds between retries, 'docker-timeout': Timeout in seconds for docker container start. For example: `Seq(uri("$WEB_HOST?retry-count=5&retry-delay=2"))`.
 compatibilityVersion  | A versioning scheme that will be included in a bundle's name that describes the level of compatibility with bundles that go before it. By default we take the major version component of a version as defined by [http://semver.org/]. However you can make this mean anything that you need it to mean in relation to bundles produced prior to it. We take the notion of a compatibility version from [http://ometer.com/parallel.html]."
-conductrTargetVersion | The version of ConductR to that this bundle can be deployed on. During bundle creation a compatibility check is made whether this bundle can be deployed on the specified ConductR version. Defaults to 1.1.
+conductrTargetVersion | The version of ConductR to that this bundle can be deployed on. During bundle creation a compatibility check is made whether this bundle can be deployed on the specified ConductR version. Defaults to 2.0.
 configurationName     | The name of the directory of the additional configuration to use. Defaults to 'default'
 diskSpace             | The amount of disk space required to host an expanded bundle and configuration. Append the letter k or K to indicate kilobytes, or m or M to indicate megabytes. Required.
-enableAcls            | Acls can be declared on an endpoint if this setting is 'true'. Otherwise only service endpoints can be declared. Endpoint acls can be used from ConductR 1.2 onwards. Therefore, the default in ConductR 1.1- is 'false' and in ConductR 1.2+ 'true'.
+enableAcls            | Acls can be declared on an endpoint if this setting is 'true'. Otherwise, only service endpoints can be declared. Endpoint acls can be used from ConductR 2.0 onwards. Therefore, the default in ConductR 1.1- is 'false' and in ConductR 2.0+ 'true'.
 endpoints             | Declares endpoints. The default is Map("web" -> Endpoint("http", 0, Set.empty)). The endpoint key is used to form a set of environment variables for your components, e.g. for the endpoint key "web" ConductR creates the environment variable `WEB_BIND_PORT`.
 executableScriptPath  | The relative path of the executableScript within the bundle.
 memory                | The amount of resident memory required to run the bundle. Use the Unix `top` command to determine this value by observing the `RES` and rounding up to the nearest 10MiB.

--- a/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
@@ -215,7 +215,7 @@ object BundleImport {
     // The order of the versions matter because there are used to compare the versions with `>=`, `<=`, etc.
     // Therefore the oldest version must come first, the latest version at last
     val V1_1 = Value("1.1")
-    val V2 = Value("2")
+    val V2_0 = Value("2.0")
   }
 
   object BundleKeys {
@@ -251,7 +251,7 @@ object BundleImport {
 
     val conductrTargetVersion = SettingKey[ConductrVersion.Value](
       "bundle-conductr-target-version",
-      "The version of ConductR to that this bundle can be deployed on. During bundle creation a compatibility check is made whether this bundle can be deployed on the specified ConductR version. Defaults to 1.1."
+      "The version of ConductR to that this bundle can be deployed on. During bundle creation a compatibility check is made whether this bundle can be deployed on the specified ConductR version. Defaults to 2.0."
     )
 
     val configurationName = SettingKey[String](

--- a/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
@@ -28,18 +28,18 @@ object BundlePlugin extends AutoPlugin {
 
   override def trigger = AllRequirements
 
-  override def projectSettings =
+  override def projectSettings: Seq[Setting[_]] =
     bundleSettings(Bundle) ++ configurationSettings(BundleConfiguration) ++
       Seq(
         bundleConfVersion := BundleConfVersion.V1,
-        conductrTargetVersion := ConductrVersion.V1_1,
+        conductrTargetVersion := ConductrVersion.V2_0,
         bundleType := Universal,
         checkInitialDelay := 3.seconds,
         checks := Seq.empty,
         compatibilityVersion := (version in Bundle).value.takeWhile(_ != '.'),
         configurationName := "default",
         endpoints := getDefaultEndpoints(Bundle).value,
-        enableAcls := conductrTargetVersion.value >= ConductrVersion.V2,
+        enableAcls := conductrTargetVersion.value >= ConductrVersion.V2_0,
         minMemoryCheckValue := 384.MiB,
         projectTarget := target.value,
         roles := Set("web"),
@@ -414,7 +414,7 @@ object BundlePlugin extends AutoPlugin {
   private def formatServiceName(serviceName: String): String =
     s"""        service-name  = "$serviceName""""
 
-  private def formatEndpoints(bundleConfVersion: BundleConfVersion.Value, endpoints: Map[String, Endpoint]): String = {
+  private def formatEndpoints(endpoints: Map[String, Endpoint]): String = {
     val formatted =
       for {
         (label, Endpoint(bindProtocol, bindPort, services, serviceName, acls)) <- endpoints
@@ -502,7 +502,7 @@ object BundlePlugin extends AutoPlugin {
           formatValue(s"""    description      = "%s"""", toString((projectInfoConfigName in config).value, (v: ModuleInfo) => v.description)) ++
           formatValue(s"""    file-system-type = "%s"""", (bundleTypeConfigName in config).value) ++
           formatValue(s"""    start-command    = %s""", toString((startCommandConfigName in config).value, (v: Seq[String]) => formatSeq(v))) ++
-          formatValue(s"""    endpoints = %s""", toString((endpointsConfigName in config).value, (v: Map[String, Endpoint]) => formatEndpoints(bundleConfVersion.value, v))) ++
+          formatValue(s"""    endpoints = %s""", toString((endpointsConfigName in config).value, (v: Map[String, Endpoint]) => formatEndpoints(v))) ++
           Seq("  }", "}") ++
           checkComponents
 

--- a/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
+++ b/src/sbt-test/bundle-plugin/acl-empty-request-mapping/build.sbt
@@ -7,7 +7,6 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 name := "acl-empty-request-mapping"
 
 version := "0.1.0-SNAPSHOT"
-BundleKeys.conductrTargetVersion := ConductrVersion.V2
 
 javaOptions in Universal := Seq(
   "-J-Xms67108864",

--- a/src/sbt-test/bundle-plugin/acl-no-service-name/build.sbt
+++ b/src/sbt-test/bundle-plugin/acl-no-service-name/build.sbt
@@ -7,7 +7,6 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 name := "acl-no-service-name"
 
 version := "0.1.0-SNAPSHOT"
-BundleKeys.conductrTargetVersion := ConductrVersion.V2
 
 javaOptions in Universal := Seq(
   "-J-Xms67108864",

--- a/src/sbt-test/bundle-plugin/basic/build.sbt
+++ b/src/sbt-test/bundle-plugin/basic/build.sbt
@@ -61,6 +61,7 @@ checkBundleConf := {
                             |      "web" = {
                             |        bind-protocol = "http"
                             |        bind-port     = 0
+                            |        service-name  = "web"
                             |        services      = []
                             |      },
                             |      "other" = {

--- a/src/sbt-test/bundle-plugin/checks/build.sbt
+++ b/src/sbt-test/bundle-plugin/checks/build.sbt
@@ -43,6 +43,7 @@ checkBundleConf := {
                             |      "web" = {
                             |        bind-protocol = "http"
                             |        bind-port     = 0
+                            |        service-name  = "web"
                             |        services      = []
                             |      }
                             |    }

--- a/src/sbt-test/bundle-plugin/overlays/build.sbt
+++ b/src/sbt-test/bundle-plugin/overlays/build.sbt
@@ -57,6 +57,7 @@ checkBundleConf := {
                             |      "web" = {
                             |        bind-protocol = "http"
                             |        bind-port     = 0
+                            |        service-name  = "web"
                             |        services      = []
                             |      }
                             |    }

--- a/src/sbt-test/bundle-plugin/validation-acl-and-service/build.sbt
+++ b/src/sbt-test/bundle-plugin/validation-acl-and-service/build.sbt
@@ -8,8 +8,6 @@ name := "validation-acl-and-service"
 
 version := "0.1.0-SNAPSHOT"
 
-BundleKeys.conductrTargetVersion := ConductrVersion.V2
-
 javaOptions in Universal := Seq(
   "-J-Xms67108864",
   "-J-Xmx67108864"

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-acls/build.sbt
@@ -9,10 +9,6 @@ lazy val simpleApi = (project in file("simple-api"))
 lazy val simpleImpl = (project in file("simple-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(simpleApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2,
-    BundleKeys.enableAcls := true
-  )
 
 // Test assertions
 val checkCassandraConf = taskKey[Unit]("")

--- a/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/cassandra-configuration-services/build.sbt
@@ -10,6 +10,7 @@ lazy val simpleImpl = (project in file("simple-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(simpleApi)
   .settings(
+    BundleKeys.conductrTargetVersion := ConductrVersion.V1_1,
     BundleKeys.enableAcls := false
   )
 

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects-single-acl/build.sbt
@@ -10,9 +10,6 @@ lazy val frontendApi = (project in file("frontend-api"))
 lazy val frontendImpl = (project in file("frontend-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(frontendApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2
-  )
 
 lazy val backendApi = (project in file("backend-api"))
   .settings(libraryDependencies += lagomJavadslApi)
@@ -20,9 +17,6 @@ lazy val backendApi = (project in file("backend-api"))
 lazy val backendImpl = (project in file("backend-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(backendApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2
-  )
 
 // Test assertions
 val checkBundleConf = taskKey[Unit]("")

--- a/src/sbt-test/lagom-bundle-plugin/multi-projects/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-projects/build.sbt
@@ -10,9 +10,6 @@ lazy val paymentApi = (project in file("payment-api"))
 lazy val paymentImpl = (project in file("payment-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(paymentApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2
-  )
 
 lazy val socialApi = (project in file("social-api"))
   .settings(libraryDependencies += lagomJavadslApi)
@@ -20,9 +17,6 @@ lazy val socialApi = (project in file("social-api"))
 lazy val socialImpl = (project in file("social-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(socialApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2
-  )
 
 // Test assertions
 val checkBundleConf = taskKey[Unit]("")

--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/build.sbt
@@ -10,9 +10,6 @@ lazy val paymentApi = (project in file("payment-api"))
 lazy val paymentImpl = (project in file("payment-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(paymentApi)
-  .settings(
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2
-  )
 
 // Test assertions
 val checkBundleConf = taskKey[Unit]("")

--- a/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service-java/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/play-and-lagom-service-java/build.sbt
@@ -15,7 +15,6 @@ lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
       "-J-Xms268435456",
       "-J-Xmx268435456"
     ),
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2,
     BundleKeys.memory := 256.MiB,
     BundleKeys.minMemoryCheckValue := 256.MiB
   )
@@ -27,7 +26,6 @@ lazy val `play-service` = (project in file("play-service"))
       "-J-Xms67108864",
       "-J-Xmx67108864"
     ),
-    BundleKeys.conductrTargetVersion := ConductrVersion.V2,
     routesGenerator := InjectedRoutesGenerator,
     BundleKeys.memory := 64.MiB,
     BundleKeys.minMemoryCheckValue := 64.MiB

--- a/src/sbt-test/lagom-bundle-plugin/with-service-endpoint-java/build.sbt
+++ b/src/sbt-test/lagom-bundle-plugin/with-service-endpoint-java/build.sbt
@@ -11,6 +11,7 @@ lazy val simpleImpl = (project in file("simple-impl"))
   .enablePlugins(LagomJava)
   .dependsOn(simpleApi)
   .settings(
+    BundleKeys.conductrTargetVersion := ConductrVersion.V1_1,
     BundleKeys.enableAcls := false
   )
 

--- a/src/sbt-test/play-bundle-plugin/custom-config/build.sbt
+++ b/src/sbt-test/play-bundle-plugin/custom-config/build.sbt
@@ -8,6 +8,7 @@ name := "custom-config"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
+BundleKeys.conductrTargetVersion := ConductrVersion.V1_1
 BundleKeys.enableAcls := false
 BundleKeys.memory := 64.MiB
 BundleKeys.minMemoryCheckValue := 64.MiB

--- a/src/sbt-test/play-bundle-plugin/play24/build.sbt
+++ b/src/sbt-test/play-bundle-plugin/play24/build.sbt
@@ -8,8 +8,6 @@ name := "play24"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
-BundleKeys.conductrTargetVersion := ConductrVersion.V2
-
 val checkBundleDist = taskKey[Unit]("check-bundle-dist-contents")
 checkBundleDist := {
   val bundleContentsConf = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")

--- a/src/sbt-test/play-bundle-plugin/play25/build.sbt
+++ b/src/sbt-test/play-bundle-plugin/play25/build.sbt
@@ -8,8 +8,6 @@ name := "play25"
 version := "0.1.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
-BundleKeys.conductrTargetVersion := ConductrVersion.V2
-
 val checkBundleDist = taskKey[Unit]("check-bundle-dist-contents")
 checkBundleDist := {
   val bundleContentsConf = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")

--- a/src/test/scala/com/lightbend/conductr/sbt/ConductrVersionSpec.scala
+++ b/src/test/scala/com/lightbend/conductr/sbt/ConductrVersionSpec.scala
@@ -9,8 +9,8 @@ class ConductrVersionSpec extends WordSpec with Matchers {
   "ConductrVersion" should {
 
     "order the versions correctly" in {
-      V1_1 < V2
-      V2 > V1_1
+      V1_1 < V2_0
+      V2_0 > V1_1
     }
   }
 }


### PR DESCRIPTION
Cherry pick of https://github.com/typesafehub/sbt-conductr/pull/215 for 2.2.x branch.