### PR TITLE
Fix netmask setup for aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ install:
   - sudo easy_install3 -U pip
   - pip3 install --user conductr-cli
   # Ensure that our sandbox interfaces are prepared
-  - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.0 up
-  - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.0 up
-  - sudo /sbin/ifconfig lo:2 192.168.10.3 netmask 255.255.255.0 up
-  - sudo /sbin/ifconfig lo:3 192.168.10.4 netmask 255.255.255.0 up
+  - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.255 up
+  - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.255 up
+  - sudo /sbin/ifconfig lo:2 192.168.10.3 netmask 255.255.255.255 up
+  - sudo /sbin/ifconfig lo:3 192.168.10.4 netmask 255.255.255.255 up
   # Prep our sandbox with some temporary credentials for CI
   - ./bin/create-credentials.sh
   # Warm up some caches so that our tests don't timeout


### PR DESCRIPTION
Same thing as the other PRs, this time for `sbt-conductr`. Explanation from https://github.com/typesafehub/conductr-cli/pull/327

> Fixes a bug with setting up address aliases. While we do want to use /24 (i.e. 255.255.255.0) for finding a network address to use, we actually always want to create the alias with a /32 (i.e. 255.255.255.255) subnet mask, as the alias itself is only interested in traffic sent directly to it. This fixes a bug on some operating systems (e.g. newer linux 4.x kernels) where network aliases respond to traffic in the same subnet -- even though it's destined for other IPs.
> 
> These changes are appropriate for MacOS as well. If other team members running MacOS could verify that your sandbox works when aliases are created with 255.255.255.255 as well, I think we're good to merge.