### PR TITLE
Add support for newly added `sandbox run --no-default-features` argument

### DIFF
--- a/src/sbt-test/sbt-conductr/sandbox-all-args/test
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/test
@@ -10,7 +10,7 @@
 > sandbox version
 
 # sandbox long args
-> sandbox run 2.0.0 --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
+> sandbox run 2.0.0 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role frontend --conductr-role backend db --feature visualization --feature logging
 > sandbox stop
 
 # sandbox short args


### PR DESCRIPTION
This adds support for newly added `sandbox run --no-default-features` argument. See https://github.com/typesafehub/conductr-cli/pull/325