### PR TITLE
bindServices must be invoked exactly once.

### DIFF
--- a/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/PaymentModule.java
+++ b/src/sbt-test/lagom-bundle-plugin/multi-services-one-project-same-service-name/payment-impl/src/main/java/impl/PaymentModule.java
@@ -12,7 +12,9 @@ import java.io.*;
 public class PaymentModule extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
-		bindServices(serviceBinding(DebitService.class, DebitServiceImpl.class));
-		bindServices(serviceBinding(CreditService.class, CreditServiceImpl.class));
+		bindServices(
+			serviceBinding(DebitService.class, DebitServiceImpl.class),
+		        serviceBinding(CreditService.class, CreditServiceImpl.class)
+		);
 	}
 }


### PR DESCRIPTION
See http://www.lagomframework.com/documentation/1.3.x/java/ServiceImplementation.html: 

>  Lagom allows you to bind multiple services, however, bindServices() may only be invoked once, as this will bind a router for Play to use to route Lagom service calls, which if bound multiple times, will cause a Guice configuration error. The first binding you specify will be considered the primaryServiceBinding and its Descriptor’s name will be used to name your Service. This name will be used by Lagom as the default value to identify your microservice when interacting with other microservices.