### PR TITLE
Travis: Use latest conductr-cli release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - sudo apt-get -qqy update
   - sudo apt-get -qqy install python3-setuptools
   - sudo easy_install3 -U pip
-  - pip3 install --user git+git://github.com/typesafehub/conductr-cli.git@master
+  - pip3 install --user conductr-cli
   # Ensure that our sandbox interfaces are prepared
   - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.255 up
   - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.255 up
@@ -27,6 +27,7 @@ install:
   - conduct load -q eslite
   - conduct load -q reactive-maps-backend-region
   - conduct load -q reactive-maps-backend-summary
+  - sandbox stop
   # Tests go faster if we do this... less interactions with bintray etc.
   - export CONDUCTR_OFFLINE_MODE=1
 


### PR DESCRIPTION
Currently, on Travis we install the master state of the conductr-cli. This can lead to errors in case that the latest commit has errors or is not compatible with released ConductR versions. See https://github.com/typesafehub/sbt-conductr/pull/226#issuecomment-285321013

This PR is installing the latest conductr-cli release on Travis instead. Also, for the other Prod-Suite components we are using the latest release instead of a snapshot version, e.g. ConductR, cinnamon, etc.