### PR TITLE
Travis: Use conductr-cli master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - sudo apt-get -qqy update
   - sudo apt-get -qqy install python3-setuptools
   - sudo easy_install3 -U pip
-  - pip3 install --user conductr-cli
+  - pip3 install --user git+git://github.com/typesafehub/conductr-cli.git@master
   # Ensure that our sandbox interfaces are prepared
   - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.255 up
   - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.255 up


### PR DESCRIPTION
Reverting PR https://github.com/typesafehub/sbt-conductr/pull/227 because it actually makes sense to test the conductr-cli master branch. sbt-conductr heavily relies on the conductr-cli and we do not have integration tests in the conductr-cli project. So the sbt-conductr integration tests are also the integration tests of the conductr-cli.

Therefore it makes sense to use the latest commit of the master branch instead of the latest conductr-cli release.

This way, we will catch errors before releasing a new conductr-cli version.