### PR TITLE
Use max 3 ConductR instances (2.2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - sudo /sbin/ifconfig lo:0 192.168.10.1 netmask 255.255.255.255 up
   - sudo /sbin/ifconfig lo:1 192.168.10.2 netmask 255.255.255.255 up
   - sudo /sbin/ifconfig lo:2 192.168.10.3 netmask 255.255.255.255 up
-  - sudo /sbin/ifconfig lo:3 192.168.10.4 netmask 255.255.255.255 up
   # Prep our sandbox with some temporary credentials for CI
   - ./bin/create-credentials.sh
   # Warm up some caches so that our tests don't timeout

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/build.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/build.sbt
@@ -33,7 +33,7 @@ checkConductrRolesByBundle := {
 val checkConductrRolesBySandboxKey = taskKey[Unit]("Check that the declared sandbox roles are used.")
 checkConductrRolesBySandboxKey := {
   val psOutput = s"ps ax".lines_!.toList
-  for (i <- 1 to 4) {
+  for (i <- 1 to 3) {
     val agent = psOutput.filter(_.contains(s"-Dconductr.agent.ip=192.168.10.$i"))
     agent should have size 1
     val expectedContent =

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/test
@@ -4,7 +4,7 @@
 
 > sandbox stop
 
-> sandbox run 2.0.2 --no-default-features --nr-of-instances 4:4 --conductr-role new-role --conductr-role other-role
+> sandbox run 2.0.2 --no-default-features --nr-of-instances 3:3 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 


### PR DESCRIPTION
The developer license we are using on our Jenkins server only supports 3 ConductR agents. This PR is adjusting the sbt tests so that we test with maximum 3 agents.