### PR TITLE
Deploy and run a LagomScala service

### DIFF
--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/build.sbt
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/build.sbt
@@ -1,5 +1,7 @@
 import org.scalatest.Matchers._
 
+import scala.util.{Failure, Success}
+
 scalaVersion in ThisBuild := "2.11.7"
 version in ThisBuild := "0.1.0-SNAPSHOT"
 
@@ -20,3 +22,41 @@ verifyConductInfo := {
 
 def conductInfo(): String =
   (Process("conduct info") #| Process(Seq("awk", "{print $2}"))).!!
+
+
+
+InputKey[Unit]("verifyIsStarted") := {
+  val args = Def.spaceDelimited().parsed
+  val bundleName = args(0)
+  DevModeBuild.waitFor[String](
+    Success(bundleStatus(bundleName).trim),
+    _.equals("101"), // 101 -->  #REPlica==1  #STaRting==0  #RUNning== 1
+    _ match {
+      case Success(msg) =>
+        val message = s"Timeout awaiting [$bundleName] to start."
+        org.scalatest.Matchers.fail(message)
+      case Failure(t) => throw t
+    }
+  )(maximumAttempts)
+  // retry _maximumAttempts_ times with a hardcoded delay between attempts of 1 sec. This doesn't consider the
+  // command execution time so this await could be around 2 minutes if `conduct info` takes 1 sec for every
+  // time it runs.
+}
+
+def bundleStatus(bundleName:String): String ={
+
+  (Process("conduct info") #| Process(Seq("grep", bundleName))  #| Process(Seq("awk", "{print $3 $4 $5}"))  ).!!
+}
+
+
+// copy/pasted from https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt#L63
+InputKey[Unit]("assertRequest") := {
+  val args = Def.spaceDelimited().parsed
+  val port = args(0)
+  val path = args(1)
+  val expect = args.drop(2).mkString(" ")
+
+  DevModeBuild.waitForRequestToContain(s"http://192.168.10.1:${port}${path}", expect)(maximumAttempts)
+}
+
+val maximumAttempts = 60

--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/lagom-service-api/src/main/scala/api/FooService.scala
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/lagom-service-api/src/main/scala/api/FooService.scala
@@ -1,20 +1,18 @@
 package api
 
 import akka.NotUsed
-import com.lightbend.lagom.scaladsl.api.ServiceCall
-import com.lightbend.lagom.scaladsl.api.Descriptor
-import com.lightbend.lagom.scaladsl.api.Service
 import com.lightbend.lagom.scaladsl.api.transport.Method
+import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
 
 trait FooService extends Service {
 
-  def foo: ServiceCall[NotUsed, NotUsed]
+  def foo: ServiceCall[NotUsed, String]
 
-  override def descriptor = {
-    import Service._
+  import Service._
 
+  override def descriptor =
     named("fooservice").withCalls(
       restCall(Method.GET, "/foo", foo)
     ).withAutoAcl(true)
-  }
+
 }

--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/lagom-service-impl/src/main/scala/impl/FooServiceImpl.scala
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/lagom-service-impl/src/main/scala/impl/FooServiceImpl.scala
@@ -1,12 +1,12 @@
 package impl
 
-import akka.NotUsed
-import com.lightbend.lagom.scaladsl.api.ServiceCall
-import scala.concurrent.Future
 import api.FooService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+
+import scala.concurrent.Future
 
 class FooServiceImpl extends FooService {
   override def foo = ServiceCall { _ =>
-    Future.successful(NotUsed)
+    Future.successful("foo-response-hardcoded in FooServiceImpl")
   }
 }

--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/project/Build.scala
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/project/Build.scala
@@ -1,0 +1,54 @@
+/* 
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import com.ning.http.client.AsyncHttpClientConfig
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+
+// copy/pasted and adapted from
+// https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/Build.scala#L9
+object DevModeBuild {
+
+  def waitForRequestToContain(uri: String, toContain: String)(totalAttempts: Int = 10): Unit = {
+    waitFor[String](
+      makeRequest(uri),
+      _.contains(toContain), {
+        case Success(msg) => s"'$msg' did not contain '$toContain'"
+        case Failure(t) =>
+          t.printStackTrace()
+          t.getMessage
+      }
+    )(totalAttempts)
+  }
+
+  def makeRequest(uri: String): Try[String] = {
+    import play.api.libs.ws._
+    import play.api.libs.ws.ning._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val config = new NingAsyncHttpClientConfigBuilder(DefaultWSClientConfig()).build()
+    val builder = new AsyncHttpClientConfig.Builder(config)
+    val wsClient:WSClient = new NingWSClient(builder.build())
+    val future = wsClient.url(uri).get().map(_.body)
+    Await.ready(future, Duration(1, "seconds"))
+    future.value.get
+  }
+
+  def waitFor[T](check: => Try[T], assertion: T => Boolean, error: Try[T] => String)(totalAttempts: Int = 10): Unit = {
+    var checks = 0
+    var actual = check
+    while ((actual.isFailure || !assertion(actual.get)) && checks < totalAttempts) {
+      Thread.sleep(1000)
+      actual = check
+      checks += 1
+    }
+    if (actual.isFailure && !assertion(actual.get)) {
+      throw new RuntimeException(error(actual))
+    }
+  }
+
+}

--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/project/plugins.sbt
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/project/plugins.sbt
@@ -1,4 +1,11 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+
+// play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
+// available in Resolver.typesafeRepo("releases")
+resolvers += Resolver.typesafeRepo("releases")
+
+libraryDependencies += "com.typesafe.play" % "play-ws_2.10" % "2.3.10"

--- a/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/test
+++ b/src/sbt-test/lagom-conductr-bundle/lagom-scala-service/test
@@ -1,8 +1,19 @@
+##
+## This test starts a sandbox, deploys a LagomScala service and executes an HTTP request through the Service
+## Gateway to ensure the service is reachable.
+## In the process, it ensures the bundle is listed in `conduct info` and also ensures an `install.sh`
+## script is created.
+##
+
 > sandbox run 2.0.2
 
 > install
 
 > verifyConductInfo
+
+> verifyIsStarted lagom-service-impl
+
+> assertRequest 9000 /foo foo-response-hardcoded in FooServiceImpl
 
 > sandbox stop
 


### PR DESCRIPTION
This is the scala equivalent of #232 to fix #231.

Improves scripted test that deploys a LagomScala service to awaits until it's reported as started by `conduct info` and then await's until there's a successful HTTP request via the sandbox service gateway.
