### PR TITLE
Promotes Play-service into a client of the Lagom-service

### DIFF
--- a/sbt-conductr-tester/lagom-bundle/README.md
+++ b/sbt-conductr-tester/lagom-bundle/README.md
@@ -1,0 +1,21 @@
+## Lagom Java Bundle tester
+
+This tester provides a lagom service and a play app acting as a client.
+
+When installed you should be able to run:
+
+```
+
+# query the lagom service directly
+$  curl http://192.168.10.1:9000/foo
+hardcoded-foo-response
+
+# query the play service directly
+$  curl http://192.168.10.1:9000/
+Hello world
+
+# query the play service (this causes a downstream call to the lagom service which is located via service locator)
+$  curl http://192.168.10.1:9000/lagom-redirect
+hardcoded-foo-response
+
+```

--- a/sbt-conductr-tester/lagom-bundle/build.sbt
+++ b/sbt-conductr-tester/lagom-bundle/build.sbt
@@ -1,3 +1,4 @@
+
 scalaVersion in ThisBuild := "2.11.8"
 version in ThisBuild := "0.1.0-SNAPSHOT"
 
@@ -9,7 +10,10 @@ lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
   .dependsOn(`lagom-service-api`)
 
 lazy val `play-service` = (project in file("play-service"))
-    .enablePlugins(PlayJava, LagomPlay)
-    .settings(
-      routesGenerator := InjectedRoutesGenerator
-    )
+  .enablePlugins(PlayJava && LagomPlay)
+  .settings(
+    routesGenerator := InjectedRoutesGenerator,
+    // Need to explicitly add the dependency to lagom-client 1.3.1 because 1.3.1-RC1 is being pulled in
+    libraryDependencies += "com.lightbend.lagom" %% "lagom-javadsl-client" % "1.3.1"
+  )
+  .dependsOn(`lagom-service-api`)

--- a/sbt-conductr-tester/lagom-bundle/lagom-service-api/src/main/java/api/FooService.java
+++ b/sbt-conductr-tester/lagom-bundle/lagom-service-api/src/main/java/api/FooService.java
@@ -1,7 +1,5 @@
 package api;
 
-import akka.stream.javadsl.Source;
-
 import akka.NotUsed;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.api.Descriptor;
@@ -11,7 +9,7 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
-  ServiceCall<NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, String> foo();
 
   @Override
   default Descriptor descriptor() {

--- a/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -1,17 +1,15 @@
 package impl;
 
 import akka.NotUsed;
-import com.lightbend.lagom.javadsl.api.ServiceCall;
-import java.util.concurrent.CompletableFuture;
-import javax.inject.Inject;
 import api.FooService;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
 
-import akka.stream.javadsl.Source;
+import java.util.concurrent.CompletableFuture;
 
 public class FooServiceImpl implements FooService {
 
   @Override
-  public ServiceCall<NotUsed, NotUsed> foo() {
-    return request -> CompletableFuture.completedFuture(NotUsed.getInstance());
+  public ServiceCall<NotUsed, String> foo() {
+    return request -> CompletableFuture.completedFuture("hardcoded-foo-response");
   }
 }

--- a/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/Module.java
+++ b/sbt-conductr-tester/lagom-bundle/lagom-service-impl/src/main/java/impl/Module.java
@@ -2,11 +2,9 @@ package impl;
 
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import com.lightbend.lagom.javadsl.api.ServiceInfo;
 import api.FooService;
-import play.*;
-import javax.inject.Inject;
-import java.util.Date;
-import java.io.*;
+import impl.FooServiceImpl;
 
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override

--- a/sbt-conductr-tester/lagom-bundle/play-service/app/Module.java
+++ b/sbt-conductr-tester/lagom-bundle/play-service/app/Module.java
@@ -1,0 +1,15 @@
+import com.lightbend.lagom.javadsl.api.ServiceAcl;
+import com.lightbend.lagom.javadsl.api.ServiceInfo;
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.client.ServiceClientGuiceSupport;
+import api.FooService;
+
+
+public class Module extends AbstractModule implements ServiceClientGuiceSupport {
+    @Override
+    protected void configure() {
+        bindServiceInfo(ServiceInfo.of("web-gateway-module", ServiceAcl.path("(?!/api/).*")));
+        bindClient(FooService.class);
+    }
+}
+

--- a/sbt-conductr-tester/lagom-bundle/play-service/app/controllers/MyController.scala
+++ b/sbt-conductr-tester/lagom-bundle/play-service/app/controllers/MyController.scala
@@ -1,14 +1,21 @@
 package controllers
 
+import java.util.concurrent.TimeUnit
 import javax.inject._
+
 import play.api._
 import play.api.mvc._
+import api.FooService
 
 @Singleton
-class MyController @Inject() extends Controller {
+class MyController @Inject()(fooService: FooService) extends Controller {
 
   def index = Action {
     Ok("Hello world")
+  }
+
+  def proxyToLagom = Action {
+    Ok(fooService.foo().invoke().toCompletableFuture.get(10, TimeUnit.SECONDS))
   }
 
 }

--- a/sbt-conductr-tester/lagom-bundle/play-service/conf/routes
+++ b/sbt-conductr-tester/lagom-bundle/play-service/conf/routes
@@ -1,4 +1,6 @@
 GET     /                           controllers.MyController.index
 
+GET     /lagom-redirect             controllers.MyController.proxyToLagom
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/sbt-conductr-tester/lagom-bundle/project/build.properties
+++ b/sbt-conductr-tester/lagom-bundle/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/sbt-conductr-tester/lagom-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0-RC2")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI


### PR DESCRIPTION
A common pattern is to deploy a play app as user facing and keep all lagom services internal. In that scenario the play app becomes a client of the lagom services.




In Lagom 1.2.x the LagomClient library didn't support that scenario so this PR is meant to help prevent regressions. This PR can't be backported to `2.2.x` because Lagom 1.2.x didn't support this scenario.