### PR TITLE
Update scripted test assertions (2.2.x)

### DIFF
--- a/src/sbt-test/public/conduct-end-to-end/build.sbt
+++ b/src/sbt-test/public/conduct-end-to-end/build.sbt
@@ -21,21 +21,21 @@ BundleKeys.diskSpace := 5.MB
 
 val verifyConductLoad = taskKey[Unit]("")
 verifyConductLoad := {
-  conductInfo() should include("""reactive-maps-backend-region      1     0     0
-                                 |reactive-maps-backend-summary     1     0     0""".stripMargin)
+  conductInfo() should include("""reactive-maps-backend-region    v1     1     0     0  intranet
+                                 |reactive-maps-backend-summary   v1     1     0     0  intranet""".stripMargin)
 }
 
 val verifyConductRun = taskKey[Unit]("")
 verifyConductRun := {
-  conductInfo() should include("""reactive-maps-backend-region      1     0     1
-                                 |reactive-maps-backend-summary     1     0     1""".stripMargin)
+  conductInfo() should include("""reactive-maps-backend-region    v1     1     0     1  intranet
+                                 |reactive-maps-backend-summary   v1     1     0     1  intranet""".stripMargin)
 }
 
 val verifyConductStop = taskKey[Unit]("")
 verifyConductStop := {
   val output = conductInfo()
-  output should include("reactive-maps-backend-region      1     0     0")
-  output should include("reactive-maps-backend-summary     1     0     0")
+  output should include("reactive-maps-backend-region    v1     1     0     0  intranet")
+  output should include("reactive-maps-backend-summary   v1     1     0     0  intranet")
 }
 
 val verifyConductUnload = taskKey[Unit]("")

--- a/src/sbt-test/public/lagom-conductr-bundle-java-service/build.sbt
+++ b/src/sbt-test/public/lagom-conductr-bundle-java-service/build.sbt
@@ -40,10 +40,8 @@ InputKey[Unit]("verifyIsStarted") := {
   // time it runs.
 }
 
-def bundleStatus(bundleName:String): String ={
-
-  (Process("conduct info") #| Process(Seq("grep", bundleName))  #| Process(Seq("awk", "{print $3 $4 $5}"))  ).!!
-}
+def bundleStatus(bundleName:String): String =
+  (Process("conduct info") #| Process(Seq("grep", bundleName))  #| Process(Seq("awk", "{print $4 $5 $6}"))  ).!!
 
 
 // copy/pasted from https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt#L63


### PR DESCRIPTION
Backport of https://github.com/typesafehub/sbt-conductr/pull/246 to 2.2.x