### PR TITLE
Update conduct info to inspect bundle

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -576,7 +576,7 @@ object ConductrPlugin extends AutoPlugin {
             runSubtask(bundleNames) |
             stopSubtask(bundleNames) |
             unloadSubtask(bundleNames) |
-            infoSubtask |
+            infoSubtask(bundleNames) |
             serviceNamesSubtask |
             aclsSubtask |
             eventsSubtask(bundleNames) |
@@ -644,10 +644,10 @@ object ConductrPlugin extends AutoPlugin {
       def unloadArgs: Parser[Option[String]] =
         hideAutoCompletion(commonArgs | waitTimeout | noWait).*.map(seqToString).?
 
-      def infoSubtask: Parser[ConductSubtaskSuccess] =
-        token("info" ~> infoArgs)
-          .map { args => ConductSubtaskSuccess("info", optionalArgs(args)) }
-          .!!!("Usage: conduct info")
+      def infoSubtask(bundleNames: Set[String]): Parser[ConductSubtaskSuccess] =
+        token("info") ~> withArgs(infoArgs)(bundleId(bundleNames).?)
+          .mapArgs { case (args, bundleIdOrName) => ConductSubtaskSuccess("info", optionalArgs(args) ++ bundleIdOrName.fold(Seq.empty[String])(Seq(_))) }
+          .!!!("Usage: conduct info --help")
       def infoArgs: Parser[Option[String]] =
         hideAutoCompletion(commonArgs).*.map(seqToString).?
 

--- a/src/sbt-test/private/sandbox-all-args/test
+++ b/src/sbt-test/private/sandbox-all-args/test
@@ -19,7 +19,7 @@
 > sandbox version
 
 # sandbox long args
-> sandbox run 2.0.2 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role web --conductr-role backend db --feature visualization --feature logging
+> sandbox run 2.0.2 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role web --conductr-role backend db --feature visualization --feature lite-logging
 > sandbox stop
 
 # sandbox short args

--- a/src/sbt-test/private/sandbox-conductr-roles/build.sbt
+++ b/src/sbt-test/private/sandbox-conductr-roles/build.sbt
@@ -1,5 +1,8 @@
 import org.scalatest.Matchers._
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.concurrent.PatienceConfiguration.{ Interval, Timeout }
 import ByteConversions._
+import scala.concurrent.duration._
 
 name := "conductr-roles"
 
@@ -19,26 +22,34 @@ BundleKeys.minMemoryCheckValue := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("bundle-role-1", "bundle-role-2")
 
+val assertionTimeout = Timeout(3.seconds)
+val assertionRetryInterval = Interval(200.millis)
+
 val checkConductrRolesByBundle = taskKey[Unit]("Check that the bundle roles are used if no sandbox roles are specified.")
 checkConductrRolesByBundle := {
-  val psOutput = s"ps ax".lines_!.toList
-  for (i <- 1 to 3) {
-    val agent = psOutput.filter(_.contains(s"-Dconductr.agent.ip=192.168.10.$i"))
-    agent should have size 1
-    val expectedContent = "-Dconductr.agent.roles.0=bundle-role-1 -Dconductr.agent.roles.1=bundle-role-2"
-    agent.head should not include(expectedContent)
+  (1 to 3).foreach { i =>
+    eventually(timeout = assertionTimeout, interval = assertionRetryInterval) {
+      val agent = psOutput.filter(_.contains(s"-Dconductr.agent.ip=192.168.10.$i"))
+      agent should have size 1
+      val expectedContent = "-Dconductr.agent.roles.0=bundle-role-1 -Dconductr.agent.roles.1=bundle-role-2"
+      agent.head should not include(expectedContent)
+    }
   }
 }
 
 val checkConductrRolesBySandboxKey = taskKey[Unit]("Check that the declared sandbox roles are used.")
 checkConductrRolesBySandboxKey := {
-  val psOutput = s"ps ax".lines_!.toList
-  for (i <- 1 to 3) {
-    val agent = psOutput.filter(_.contains(s"-Dconductr.agent.ip=192.168.10.$i"))
-    agent should have size 1
-    val expectedContent =
-      if(i % 2 == 1) "-Dconductr.agent.roles.0=new-role"
-      else           "-Dconductr.agent.roles.0=other-role"
-    agent.head should include(expectedContent)
+  (1 to 3).foreach { i =>
+    eventually(timeout = assertionTimeout, interval = assertionRetryInterval) {
+      val agent = psOutput.filter(_.contains(s"-Dconductr.agent.ip=192.168.10.$i"))
+      agent should have size 1
+      val expectedContent =
+        if(i % 2 == 1) "-Dconductr.agent.roles.0=new-role"
+        else           "-Dconductr.agent.roles.0=other-role"
+      agent.head should include(expectedContent)
+    }
   }
 }
+
+def psOutput: Seq[String] =
+  "ps ax".lines_!.toList

--- a/src/sbt-test/private/sandbox-end-to-end/test
+++ b/src/sbt-test/private/sandbox-end-to-end/test
@@ -1,4 +1,4 @@
-> sandbox run 2.0.2 --nr-of-instances 3:3 --feature visualization --feature monitoring --port 1111 --port 2222 --port 2551
+> sandbox run 2.0.2 --nr-of-instances 3:3 --port 1111 --port 2222 --port 2551
 
 # sandbox checks
 > checkInstances3

--- a/src/sbt-test/public/conduct-end-to-end/test
+++ b/src/sbt-test/public/conduct-end-to-end/test
@@ -4,6 +4,9 @@
 # conduct info
 > conduct info
 
+# conduct info eslite
+> conduct info eslite
+
 # conduct service-names
 > conduct service-names
 


### PR DESCRIPTION
This is to update sbt-conductr to match with changes to `conduct info` as part of released version `1.1.0`.

From CLI version `1.1.0` the `conduct info` command accepts bundle id or bundle name as optional input argument, allowing inspection of bundle.