### PR TITLE
Permit string path and re-write path combinations

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundleImport.scala
@@ -6,7 +6,9 @@ package com.lightbend.conductr.sbt
 
 import sbt._
 import com.typesafe.sbt.SbtNativePackager.Universal
+
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
 import scala.util.matching.Regex
 
 object BundleImport {
@@ -53,7 +55,7 @@ object BundleImport {
       Request(None, Right(r), None)
 
     implicit def request2(r: (String, String)): Request =
-      Request(Some(r._1), Left(r._2), None)
+      Try(Request(Some(r._1), Left(r._2), None)).toOption.getOrElse(Request(None, Left(r._1), Some(r._2)))
     implicit def regexRequest2(r: (String, Regex)): Request =
       Request(Some(r._1), Right(r._2), None)
     implicit def regexToStringRequest2(r: (Regex, String)): Request =

--- a/src/sbt-test/public/bundle-plugin-validation-acl-and-service/build.sbt
+++ b/src/sbt-test/public/bundle-plugin-validation-acl-and-service/build.sbt
@@ -31,7 +31,8 @@ BundleKeys.endpoints += "ping-service" -> Endpoint("http", 0, Some(Set(URI("http
           "GET" -> "^/beg-3".r -> "/other-beg-3",
           "/regex1/[a|b|c]".r,
           "GET" -> "/regex2/[a|b|c]".r,
-          "GET" -> "/regex3/[a|b|c]".r -> "/other-regex-3"
+          "GET" -> "/regex3/[a|b|c]".r -> "/other-regex-3",
+          "/bar-2" -> "/bar-3"
         )),
       RequestAcl(Tcp(9001, 9002)),
       RequestAcl(Udp(19001, 19002))


### PR DESCRIPTION
This commit permits the scenario where a string path and its rewrite path can be specified for all request methods. Without this fix, an sbt error would occur due to the enumeration "withName" method failing.