### PR TITLE
Use name bundle-status for status component (2.2.x)

### DIFF
--- a/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/BundlePlugin.scala
@@ -477,7 +477,7 @@ object BundlePlugin extends AutoPlugin {
           Seq(
             value.map(uri => s""""$uri"""").mkString(
               s"""components = {
-                  |  ${(normalizedName in config).value}-status = {
+                  |  bundle-status = {
                   |    description      = "Status check for the bundle component"
                   |    file-system-type = "universal"
                   |    start-command    = ["check", "--initial-delay", "$checkInitialDelayInSeconds", """.stripMargin,

--- a/src/sbt-test/public/bundle-plugin-checks/build.sbt
+++ b/src/sbt-test/public/bundle-plugin-checks/build.sbt
@@ -52,7 +52,7 @@ checkBundleConf := {
                             |  }
                             |}
                             |components = {
-                            |  checks-status = {
+                            |  bundle-status = {
                             |    description      = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command    = ["check", "--initial-delay", "1", "$CHECKS_HOST?retry-count=5&retry-delay=3"]


### PR DESCRIPTION
Prior to this change, the name of the status component was derived from the bundle component. Example: A status component was named "my-bundle-status" if the bundle component name was "my-bundle". This logic makes it difficult to filter for the status component, especially if the bundle component contains the substring "status" as well.

Now, we name the status component always "bundle-status" to make it simplier to search for a status component, e.g. in the `conductr-cli` to auto-detect components.