### PR TITLE
Update tests to ConductR 2.0.5 (2.2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   # Prep our sandbox with some temporary credentials for CI
   - ./bin/create-credentials.sh
   # Warm up some caches so that our tests don't timeout
-  - sandbox run 2.0.2 -f visualization -f monitoring > /dev/null
+  - sandbox run 2.0.5 -f visualization -f monitoring > /dev/null
   - conduct load -q cassandra
   - conduct load -q cinnamon-grafana-docker
   - conduct load -q eslite

--- a/src/sbt-test/private/sandbox-all-args/test
+++ b/src/sbt-test/private/sandbox-all-args/test
@@ -19,9 +19,9 @@
 > sandbox version
 
 # sandbox long args
-> sandbox run 2.0.2 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role web --conductr-role backend db --feature visualization --feature lite-logging
+> sandbox run 2.0.5 --no-default-features --port 1111 --port 2222 --image typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr --nr-of-instances 1 --log-level debug --env key1=value1 --env key2=value2 --conductr-role web --conductr-role backend db --feature visualization --feature lite-logging
 > sandbox stop
 
 # sandbox short args
-> sandbox run 2.0.2 --no-default-features -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r web -r backend db -f visualization -f lite-logging
+> sandbox run 2.0.5 --no-default-features -p 1111 -p 2222 -i typesafe-docker-registry-for-subscribers-only.bintray.io/conductr/conductr -n 3 -l debug -e key1=value1 -e key2=value2 -r web -r backend db -f visualization -f lite-logging
 > sandbox stop

--- a/src/sbt-test/private/sandbox-conductr-roles/test
+++ b/src/sbt-test/private/sandbox-conductr-roles/test
@@ -1,10 +1,10 @@
-> sandbox run 2.0.2 --no-default-features --nr-of-instances 3:3
+> sandbox run 2.0.5 --no-default-features --nr-of-instances 3:3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> sandbox run 2.0.2 --no-default-features --nr-of-instances 3:3 --conductr-role new-role --conductr-role other-role
+> sandbox run 2.0.5 --no-default-features --nr-of-instances 3:3 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/private/sandbox-end-to-end/test
+++ b/src/sbt-test/private/sandbox-end-to-end/test
@@ -1,4 +1,4 @@
-> sandbox run 2.0.2 --nr-of-instances 3:3 --port 1111 --port 2222 --port 2551
+> sandbox run 2.0.5 --nr-of-instances 3:3 --port 1111 --port 2222 --port 2551
 
 # sandbox checks
 > checkInstances3

--- a/src/sbt-test/public/conduct-end-to-end/test
+++ b/src/sbt-test/public/conduct-end-to-end/test
@@ -1,5 +1,5 @@
 # run sandbox
-> sandbox run 2.0.2
+> sandbox run 2.0.5
 
 # conduct info
 > conduct info

--- a/src/sbt-test/public/lagom-conductr-bundle-java-service/test
+++ b/src/sbt-test/public/lagom-conductr-bundle-java-service/test
@@ -5,7 +5,7 @@
 ## script is created.
 ##
 
-> sandbox run 2.0.2
+> sandbox run 2.0.5
 
 > install
 

--- a/src/sbt-test/public/sandbox-ports-override-endpoints/test
+++ b/src/sbt-test/public/sandbox-ports-override-endpoints/test
@@ -1,4 +1,4 @@
-> sandbox run 2.0.2
+> sandbox run 2.0.5
 
 > checkPorts
 


### PR DESCRIPTION
Backport of https://github.com/typesafehub/sbt-conductr/pull/266 to 2.2.x