### PR TITLE
Update Lagom to 1.3.5 in tests

### DIFF
--- a/sbt-conductr-tester/lagom-java-bundle/build.sbt
+++ b/sbt-conductr-tester/lagom-java-bundle/build.sbt
@@ -12,8 +12,6 @@ lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
 lazy val `play-service` = (project in file("play-service"))
   .enablePlugins(PlayJava && LagomPlay)
   .settings(
-    routesGenerator := InjectedRoutesGenerator,
-    // Need to explicitly add the dependency to lagom-client 1.3.1 because 1.3.1-RC1 is being pulled in
-    libraryDependencies += "com.lightbend.lagom" %% "lagom-javadsl-client" % "1.3.1"
+    routesGenerator := InjectedRoutesGenerator
   )
   .dependsOn(`lagom-service-api`)

--- a/sbt-conductr-tester/lagom-java-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-java-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/sbt-conductr-tester/lagom-scala-bundle/build.sbt
+++ b/sbt-conductr-tester/lagom-scala-bundle/build.sbt
@@ -15,9 +15,6 @@ lazy val `play-service` = (project in file("play-service"))
   .enablePlugins(PlayScala, LagomPlay)
   .settings(
     routesGenerator := InjectedRoutesGenerator,
-    // Need to explicitly add the dependency to lagom-client 1.3.1 because 1.3.1-RC1 is being pulled in
-    libraryDependencies ++= Seq(
-      "com.lightbend.lagom" %% "lagom-scaladsl-client" % "1.3.1",
-      macwire)
+    libraryDependencies += macwire
   )
   .dependsOn(`lagom-service-api`)

--- a/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -1,6 +1,8 @@
 package impl
 
 import api._
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.devmode._
 import com.lightbend.lagom.scaladsl.server._
 import com.softwaremill.macwire.wire
@@ -17,7 +19,11 @@ abstract class FooApplication(context: LagomApplicationContext) extends LagomApp
 
 class FooApplicationLoader extends LagomApplicationLoader {
   override def load(context: LagomApplicationContext): LagomApplication =
-    new FooApplication(context) with ConductRApplicationComponents
+    new FooApplication(context) with ConductRApplicationComponents {
+      // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+      override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+        new CircuitBreakerMetricsProviderImpl(actorSystem)
+    }
 
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new FooApplication(context) with LagomDevModeComponents

--- a/sbt-conductr-tester/lagom-scala-bundle/play-service/app/PlayGatewayLoader.scala
+++ b/sbt-conductr-tester/lagom-scala-bundle/play-service/app/PlayGatewayLoader.scala
@@ -1,4 +1,6 @@
 import api.FooService
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.api.{ServiceAcl, ServiceInfo}
 import com.lightbend.lagom.scaladsl.client.LagomServiceClientComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
@@ -44,6 +46,10 @@ class PlayGatewayLoader extends ApplicationLoader {
     case Mode.Dev =>
       new PlayGateway(context) with LagomDevModeComponents {}.application
     case _ =>
-      new PlayGateway(context) with ConductRServiceLocatorComponents with ConductRLifecycleComponents {}.application
+      new PlayGateway(context) with ConductRServiceLocatorComponents with ConductRLifecycleComponents {
+        // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+        override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+          new CircuitBreakerMetricsProviderImpl(actorSystem)
+      }.application
   }
 }

--- a/sbt-conductr-tester/lagom-scala-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-scala-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/src/sbt-test/public/conduct-end-to-end/build.sbt
+++ b/src/sbt-test/public/conduct-end-to-end/build.sbt
@@ -21,14 +21,16 @@ BundleKeys.diskSpace := 5.MB
 
 val verifyConductLoad = taskKey[Unit]("")
 verifyConductLoad := {
-  conductInfo() should include("""reactive-maps-backend-region    v1     1     0     0  intranet
-                                 |reactive-maps-backend-summary   v1     1     0     0  intranet""".stripMargin)
+  val output = conductInfo()
+  output should include("reactive-maps-backend-region    v1     1     0     0  intranet")
+  output should include("reactive-maps-backend-summary   v1     1     0     0  intranet")
 }
 
 val verifyConductRun = taskKey[Unit]("")
 verifyConductRun := {
-  conductInfo() should include("""reactive-maps-backend-region    v1     1     0     1  intranet
-                                 |reactive-maps-backend-summary   v1     1     0     1  intranet""".stripMargin)
+  val output = conductInfo()
+  output should include("reactive-maps-backend-region    v1     1     0     1  intranet")
+  output should include("reactive-maps-backend-summary   v1     1     0     1  intranet")
 }
 
 val verifyConductStop = taskKey[Unit]("")

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -4,6 +4,8 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.util.Date
 
 import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.server._
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -12,7 +14,11 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents
+		new FooApplication(context) with ConductRApplicationComponents {
+			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+				new CircuitBreakerMetricsProviderImpl(actorSystem)
+		}
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/play-service/app/Loader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/play-service/app/Loader.scala
@@ -1,3 +1,5 @@
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.api.{ServiceAcl, ServiceInfo}
 import com.lightbend.lagom.scaladsl.client.LagomServiceClientComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
@@ -38,6 +40,10 @@ class MyLoader extends ApplicationLoader {
     case Mode.Dev =>
       new MyApplication(context) with LagomDevModeComponents {}.application
     case _ =>
-      new MyApplication(context) with ConductRApplicationComponents {}.application
+      new MyApplication(context) with ConductRApplicationComponents {
+        // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+        override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+          new CircuitBreakerMetricsProviderImpl(actorSystem)
+      }.application
   }
 }

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
@@ -4,6 +4,8 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.util.Date
 
 import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.server._
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -12,13 +14,17 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents
+		new FooApplication(context) with ConductRApplicationComponents {
+			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+				new CircuitBreakerMetricsProviderImpl(actorSystem)
+		}
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents
 
 	override def describeServices = List(
-			readDescriptor[FooService]
+		readDescriptor[FooService]
   )
 }
 

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -4,6 +4,8 @@ import java.nio.file.{Files, StandardOpenOption}
 import java.util.Date
 
 import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.server._
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -12,7 +14,11 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents
+		new FooApplication(context) with ConductRApplicationComponents {
+			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+				new CircuitBreakerMetricsProviderImpl(actorSystem)
+		}
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 


### PR DESCRIPTION
This requires working around the conflicting `circuitBreakerMetricsProvider` definitions in `ConductRServiceLocatorComponents` and `LagomServiceClientComponents`.

See typesafehub/conductr-lib#145 for details.