### PR TITLE
Add tests for LagomApplicationLoader.describeService

### DIFF
--- a/sbt-conductr-tester/lagom-java-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-java-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -28,7 +28,5 @@ class FooApplicationLoader extends LagomApplicationLoader {
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new FooApplication(context) with LagomDevModeComponents
 
-  override def describeServices = List(
-    readDescriptor[FooService]
-  )
+  override def describeService = Some(readDescriptor[FooService])
 }

--- a/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/sbt-conductr-tester/lagom-scala-bundle/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -19,11 +19,7 @@ abstract class FooApplication(context: LagomApplicationContext) extends LagomApp
 
 class FooApplicationLoader extends LagomApplicationLoader {
   override def load(context: LagomApplicationContext): LagomApplication =
-    new FooApplication(context) with ConductRApplicationComponents {
-      // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-      override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-        new CircuitBreakerMetricsProviderImpl(actorSystem)
-    }
+    new FooApplication(context) with ConductRApplicationComponents
 
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new FooApplication(context) with LagomDevModeComponents

--- a/sbt-conductr-tester/lagom-scala-bundle/play-service/app/PlayGatewayLoader.scala
+++ b/sbt-conductr-tester/lagom-scala-bundle/play-service/app/PlayGatewayLoader.scala
@@ -46,10 +46,6 @@ class PlayGatewayLoader extends ApplicationLoader {
     case Mode.Dev =>
       new PlayGateway(context) with LagomDevModeComponents {}.application
     case _ =>
-      new PlayGateway(context) with ConductRServiceLocatorComponents with ConductRLifecycleComponents {
-        // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-        override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-          new CircuitBreakerMetricsProviderImpl(actorSystem)
-      }.application
+      new PlayGateway(context) with ConductRServiceLocatorComponents with ConductRLifecycleComponents.application
   }
 }

--- a/sbt-conductr-tester/lagom-scala-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/lagom-scala-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -23,9 +23,7 @@ class FooLoader extends LagomApplicationLoader {
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents
 
-	override def describeServices = List(
-		readDescriptor[FooService]
-	)
+	override def describeService = Some(readDescriptor[FooService])
 }
 
 abstract class FooApplication(context: LagomApplicationContext)

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -14,11 +14,7 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents {
-			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-				new CircuitBreakerMetricsProviderImpl(actorSystem)
-		}
+		new FooApplication(context) with ConductRApplicationComponents
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/play-service/app/Loader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/play-service/app/Loader.scala
@@ -40,10 +40,6 @@ class MyLoader extends ApplicationLoader {
     case Mode.Dev =>
       new MyApplication(context) with LagomDevModeComponents {}.application
     case _ =>
-      new MyApplication(context) with ConductRApplicationComponents {
-        // Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-        override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-          new CircuitBreakerMetricsProviderImpl(actorSystem)
-      }.application
+      new MyApplication(context) with ConductRApplicationComponents {}.application
   }
 }

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
@@ -20,9 +20,7 @@ class FooLoader extends LagomApplicationLoader {
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents
 
-	override def describeServices = List(
-		readDescriptor[FooService]
-  )
+	override def describeService = Some(readDescriptor[FooService])
 }
 
 abstract class FooApplication(context: LagomApplicationContext)

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/simple-impl/src/main/scala/impl/FooLoader.scala
@@ -11,11 +11,7 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents {
-			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-				new CircuitBreakerMetricsProviderImpl(actorSystem)
-		}
+		new FooApplication(context) with ConductRApplicationComponents
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/build.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/build.sbt
@@ -1,0 +1,57 @@
+import org.scalatest.Matchers._
+
+import scala.util.{Failure, Success, Try}
+
+scalaVersion in ThisBuild := "2.11.7"
+version in ThisBuild := "0.1.0-SNAPSHOT"
+
+lazy val `lagom-service-api` = (project in file("lagom-service-api"))
+  .settings(libraryDependencies += lagomJavadslApi)
+
+lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
+  .enablePlugins(LagomJava)
+  .dependsOn(`lagom-service-api`)
+
+// Test assertions
+val verifyConductInfo = taskKey[Unit]("")
+verifyConductInfo := {
+  val output = conductInfo()
+  output should include("lagom-service-impl")
+}
+
+def conductInfo(): String =
+  (Process("conduct info") #| Process(Seq("awk", "{print $2}"))).!!
+
+InputKey[Unit]("verifyIsStarted") := {
+  val args = Def.spaceDelimited().parsed
+  val bundleName = args(0)
+  DevModeBuild.waitFor[String](
+    Success(bundleStatus(bundleName).trim),
+    _.equals("101"), // 101 -->  #REPlica==1  #STaRting==0  #RUNning== 1
+    _ match {
+      case Success(msg) =>
+        val message = s"Timeout awaiting [$bundleName] to start."
+        org.scalatest.Matchers.fail(message)
+      case Failure(t) => throw t
+    }
+  )(maximumAttempts)
+  // retry _maximumAttempts_ times with a hardcoded delay between attempts of 1 sec. This doesn't consider the
+  // command execution time so this await could be around 2 minutes if `conduct info` takes 1 sec for every
+  // time it runs.
+}
+
+def bundleStatus(bundleName:String): String =
+  (Process("conduct info") #| Process(Seq("grep", bundleName))  #| Process(Seq("awk", "{print $4 $5 $6}"))  ).!!
+
+
+// copy/pasted from https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt#L63
+InputKey[Unit]("assertRequest") := {
+  val args = Def.spaceDelimited().parsed
+  val port = args(0)
+  val path = args(1)
+  val expect = args.drop(2).mkString(" ")
+
+  DevModeBuild.waitForRequestToContain(s"http://192.168.10.1:${port}${path}", expect)(maximumAttempts)
+}
+
+val maximumAttempts = 60

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-api/src/main/java/api/FooService.java
@@ -1,0 +1,22 @@
+package api;
+
+import akka.stream.javadsl.Source;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+public interface FooService extends Service {
+
+  ServiceCall<NotUsed, String> foo();
+
+  @Override
+  default Descriptor descriptor() {
+    return named("fooservice").withCalls(
+      restCall(Method.GET, "/foo", this::foo)
+    ).withAutoAcl(true);
+  }
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/java/impl/FooServiceImpl.java
@@ -1,0 +1,17 @@
+package impl;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import java.util.concurrent.CompletableFuture;
+import javax.inject.Inject;
+import api.FooService;
+
+import akka.stream.javadsl.Source;
+
+public class FooServiceImpl implements FooService {
+
+  @Override
+  public ServiceCall<NotUsed, String> foo() {
+    return request -> CompletableFuture.completedFuture("foo-response-hardcoded in FooServiceImpl");
+  }
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/java/impl/Module.java
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/java/impl/Module.java
@@ -1,0 +1,16 @@
+package impl;
+
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import api.FooService;
+import play.*;
+import javax.inject.Inject;
+import java.util.Date;
+import java.io.*;
+
+public class Module extends AbstractModule implements ServiceGuiceSupport {
+	@Override
+	protected void configure() {
+		bindServices(serviceBinding(FooService.class, FooServiceImpl.class));
+	}
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/resources/application.conf
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/lagom-service-impl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.modules.enabled += impl.Module

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/Build.scala
@@ -1,0 +1,54 @@
+/* 
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import com.ning.http.client.AsyncHttpClientConfig
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+
+// copy/pasted and adapted from
+// https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/Build.scala#L9
+object DevModeBuild {
+
+  def waitForRequestToContain(uri: String, toContain: String)(totalAttempts: Int = 10): Unit = {
+    waitFor[String](
+      makeRequest(uri),
+      _.contains(toContain), {
+        case Success(msg) => s"'$msg' did not contain '$toContain'"
+        case Failure(t) =>
+          t.printStackTrace()
+          t.getMessage
+      }
+    )(totalAttempts)
+  }
+
+  def makeRequest(uri: String): Try[String] = {
+    import play.api.libs.ws._
+    import play.api.libs.ws.ning._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val config = new NingAsyncHttpClientConfigBuilder(DefaultWSClientConfig()).build()
+    val builder = new AsyncHttpClientConfig.Builder(config)
+    val wsClient:WSClient = new NingWSClient(builder.build())
+    val future = wsClient.url(uri).get().map(_.body)
+    Await.ready(future, Duration(1, "seconds"))
+    future.value.get
+  }
+
+  def waitFor[T](check: => Try[T], assertion: T => Boolean, error: Try[T] => String)(totalAttempts: Int = 10): Unit = {
+    var checks = 0
+    var actual = check
+    while ((actual.isFailure || !assertion(actual.get)) && checks < totalAttempts) {
+      Thread.sleep(1000)
+      actual = check
+      checks += 1
+    }
+    if (actual.isFailure && !assertion(actual.get)) {
+      throw new RuntimeException(error(actual))
+    }
+  }
+
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/plugins.sbt
@@ -1,0 +1,12 @@
+// This is intentionally set to an old version to test backward compatibility
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0")
+
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+
+// play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
+// available in Resolver.typesafeRepo("releases")
+resolvers += Resolver.typesafeRepo("releases")
+
+libraryDependencies += "com.typesafe.play" % "play-ws_2.10" % "2.3.10"

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/test
@@ -1,0 +1,22 @@
+##
+## This test starts a sandbox, deploys a LagomJava service and executes an HTTP request through the Service
+## Gateway to ensure the service is reachable. It intentionally uses an old version of Lagom to test for
+## backward compatibility.
+## In the process, it ensures the bundle is listed in `conduct info` and also ensures an `install.sh`
+## script is created.
+##
+
+> sandbox run 2.0.5
+
+> install
+
+> verifyConductInfo
+
+> verifyIsStarted lagom-service-impl
+
+> assertRequest 9000 /foo foo-response-hardcoded in FooServiceImpl
+
+> sandbox stop
+
+> generateInstallationScript
+$ exists target/install.sh

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/build.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/build.sbt
@@ -1,0 +1,60 @@
+import org.scalatest.Matchers._
+
+import scala.util.{Failure, Success}
+
+scalaVersion in ThisBuild := "2.11.7"
+version in ThisBuild := "0.1.0-SNAPSHOT"
+
+lazy val `lagom-service-api` = (project in file("lagom-service-api"))
+  .settings(libraryDependencies += lagomScaladslApi)
+
+lazy val `lagom-service-impl` = (project in file("lagom-service-impl"))
+  .enablePlugins(LagomScala)
+  .dependsOn(`lagom-service-api`)
+
+// Test assertions
+val verifyConductInfo = taskKey[Unit]("")
+verifyConductInfo := {
+  val output = conductInfo()
+  output should include("lagom-service-impl")
+  output should include("cassandra")
+}
+
+def conductInfo(): String =
+  (Process("conduct info") #| Process(Seq("awk", "{print $2}"))).!!
+
+
+
+InputKey[Unit]("verifyIsStarted") := {
+  val args = Def.spaceDelimited().parsed
+  val bundleName = args(0)
+  DevModeBuild.waitFor[String](
+    Success(bundleStatus(bundleName).trim),
+    _.equals("101"), // 101 -->  #REPlica==1  #STaRting==0  #RUNning== 1
+    _ match {
+      case Success(msg) =>
+        val message = s"Timeout awaiting [$bundleName] to start."
+        org.scalatest.Matchers.fail(message)
+      case Failure(t) => throw t
+    }
+  )(maximumAttempts)
+  // retry _maximumAttempts_ times with a hardcoded delay between attempts of 1 sec. This doesn't consider the
+  // command execution time so this await could be around 2 minutes if `conduct info` takes 1 sec for every
+  // time it runs.
+}
+
+def bundleStatus(bundleName:String): String =
+  (Process("conduct info") #| Process(Seq("grep", bundleName))  #| Process(Seq("awk", "{print $4 $5 $6}"))  ).!!
+
+
+// copy/pasted from https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt#L63
+InputKey[Unit]("assertRequest") := {
+  val args = Def.spaceDelimited().parsed
+  val port = args(0)
+  val path = args(1)
+  val expect = args.drop(2).mkString(" ")
+
+  DevModeBuild.waitForRequestToContain(s"http://192.168.10.1:${port}${path}", expect)(maximumAttempts)
+}
+
+val maximumAttempts = 60

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-api/src/main/scala/api/FooService.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-api/src/main/scala/api/FooService.scala
@@ -1,0 +1,18 @@
+package api
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api.transport.Method
+import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
+
+trait FooService extends Service {
+
+  def foo: ServiceCall[NotUsed, String]
+
+  import Service._
+
+  override def descriptor =
+    named("fooservice").withCalls(
+      restCall(Method.GET, "/foo", foo)
+    ).withAutoAcl(true)
+
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/resources/application.conf
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.application.loader = impl.FooLoader

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -1,0 +1,42 @@
+package impl
+
+import java.nio.file.{Files, StandardOpenOption}
+import java.util.Date
+
+import com.typesafe.conductr.bundlelib.lagom.scaladsl.ConductRApplicationComponents
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
+import com.lightbend.lagom.scaladsl.server._
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import play.api.libs.ws.ahc.AhcWSComponents
+import api.FooService
+
+class FooLoader extends LagomApplicationLoader {
+
+	override def load(context: LagomApplicationContext): LagomApplication =
+		new FooApplication(context) with ConductRApplicationComponents {
+			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+				new CircuitBreakerMetricsProviderImpl(actorSystem)
+		}
+
+	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+		new FooApplication(context) with LagomDevModeComponents {
+			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
+			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
+				new CircuitBreakerMetricsProviderImpl(actorSystem)
+		}
+
+  override def describeServices = List(
+    readDescriptor[FooService]
+  )
+}
+
+abstract class FooApplication(context: LagomApplicationContext)
+	extends LagomApplication(context)
+		with AhcWSComponents {
+
+	override lazy val lagomServer = LagomServer.forServices(
+		bindService[FooService].to(new FooServiceImpl)
+	)
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/scala/impl/FooServiceImpl.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/lagom-service-impl/src/main/scala/impl/FooServiceImpl.scala
@@ -1,0 +1,12 @@
+package impl
+
+import api.FooService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+
+import scala.concurrent.Future
+
+class FooServiceImpl extends FooService {
+  override def foo = ServiceCall { _ =>
+    Future.successful("foo-response-hardcoded in FooServiceImpl")
+  }
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/Build.scala
@@ -1,0 +1,54 @@
+/* 
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import com.ning.http.client.AsyncHttpClientConfig
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.{Failure, Success, Try}
+
+// copy/pasted and adapted from
+// https://github.com/lagom/lagom/blob/d9f4df0f56f7c567e88602fa91698b8d8f5de3d9/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/Build.scala#L9
+object DevModeBuild {
+
+  def waitForRequestToContain(uri: String, toContain: String)(totalAttempts: Int = 10): Unit = {
+    waitFor[String](
+      makeRequest(uri),
+      _.contains(toContain), {
+        case Success(msg) => s"'$msg' did not contain '$toContain'"
+        case Failure(t) =>
+          t.printStackTrace()
+          t.getMessage
+      }
+    )(totalAttempts)
+  }
+
+  def makeRequest(uri: String): Try[String] = {
+    import play.api.libs.ws._
+    import play.api.libs.ws.ning._
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val config = new NingAsyncHttpClientConfigBuilder(DefaultWSClientConfig()).build()
+    val builder = new AsyncHttpClientConfig.Builder(config)
+    val wsClient:WSClient = new NingWSClient(builder.build())
+    val future = wsClient.url(uri).get().map(_.body)
+    Await.ready(future, Duration(1, "seconds"))
+    future.value.get
+  }
+
+  def waitFor[T](check: => Try[T], assertion: T => Boolean, error: Try[T] => String)(totalAttempts: Int = 10): Unit = {
+    var checks = 0
+    var actual = check
+    while ((actual.isFailure || !assertion(actual.get)) && checks < totalAttempts) {
+      Thread.sleep(1000)
+      actual = check
+      checks += 1
+    }
+    if (actual.isFailure && !assertion(actual.get)) {
+      throw new RuntimeException(error(actual))
+    }
+  }
+
+}

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/plugins.sbt
@@ -1,0 +1,12 @@
+// This is intentionally set to an old version to test backward compatibility
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0")
+
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+
+// play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
+// available in Resolver.typesafeRepo("releases")
+resolvers += Resolver.typesafeRepo("releases")
+
+libraryDependencies += "com.typesafe.play" % "play-ws_2.10" % "2.3.10"

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/test
@@ -1,0 +1,22 @@
+##
+## This test starts a sandbox, deploys a LagomScala service and executes an HTTP request through the Service
+## Gateway to ensure the service is reachable. It intentionally uses an old version of Lagom and deprecated APIs,
+## to test for backward compatibility.
+## In the process, it ensures the bundle is listed in `conduct info` and also ensures an `install.sh`
+## script is created.
+##
+
+> sandbox run 2.0.5
+
+> install
+
+> verifyConductInfo
+
+> verifyIsStarted lagom-service-impl
+
+> assertRequest 9000 /foo foo-response-hardcoded in FooServiceImpl
+
+> sandbox stop
+
+> generateInstallationScript
+$ exists target/install.sh

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -23,9 +23,7 @@ class FooLoader extends LagomApplicationLoader {
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents
 
-  override def describeServices = List(
-    readDescriptor[FooService]
-  )
+  override def describeService = Some(readDescriptor[FooService])
 }
 
 abstract class FooApplication(context: LagomApplicationContext)

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/lagom-service-impl/src/main/scala/impl/FooLoader.scala
@@ -14,11 +14,7 @@ import api.FooService
 class FooLoader extends LagomApplicationLoader {
 
 	override def load(context: LagomApplicationContext): LagomApplication =
-		new FooApplication(context) with ConductRApplicationComponents {
-			// Workaround for https://github.com/typesafehub/conductr-lib/issues/145
-			override lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider =
-				new CircuitBreakerMetricsProviderImpl(actorSystem)
-		}
+		new FooApplication(context) with ConductRApplicationComponents
 
 	override def loadDevMode(context: LagomApplicationContext): LagomApplication =
 		new FooApplication(context) with LagomDevModeComponents

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.6")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 


### PR DESCRIPTION
Fixes #273 

The first commit contains only tests for the deprecated API, which should succeed.

I expect subsequent commits to fail until Lagom 1.3.6 is released. I'm opening a WIP pull request so this can be verified against Travis.

I'll advise when this is ready to merge.