### PR TITLE
Bump up the versions

### DIFF
--- a/sbt-conductr-tester/play-bundle/project/plugins.sbt
+++ b/sbt-conductr-tester/play-bundle/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../../").getCanonicalFile.toURI

--- a/src/main/scala/com/lightbend/conductr/sbt/package.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/package.scala
@@ -66,7 +66,7 @@ package object sbt {
     def playConductrBundleLib(playVersion: String, scalaVersion: String, conductrLibVersion: String) =
       "com.typesafe.conductr" % s"play${formatVersionMajorMinor(playVersion)}-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
     def lagomConductrBundleLib(language: String, lagomVersion: String, scalaVersion: String, conductrLibVersion: String) =
-      "com.typesafe.conductr" % s"lagom${formatVersionMajor(lagomVersion)}-$language-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
+      "com.typesafe.conductr" % s"lagom${formatVersionMajorMinor(lagomVersion)}-$language-conductr-bundle-lib_$scalaVersion" % conductrLibVersion
 
     private def formatVersionMajorMinor(version: String): String =
       version.filterNot(_ == '.').take(2)
@@ -76,7 +76,7 @@ package object sbt {
   }
 
   object Version {
-    val conductrBundleLib = "1.9.4"
+    val conductrBundleLib = "2.0.0"
   }
 
   /**

--- a/src/test/scala/com/lightbend/conductr/sbt/PackageSpec.scala
+++ b/src/test/scala/com/lightbend/conductr/sbt/PackageSpec.scala
@@ -11,8 +11,8 @@ class PackageSpec extends WordSpec with Matchers {
     }
 
     "return ConductR Lib support for Lagom" in {
-      val result = Library.lagomConductrBundleLib(language = "java", lagomVersion = "1.0.0", scalaVersion = "2.11", conductrLibVersion = "1.1.3")
-      result shouldBe ("com.typesafe.conductr" % s"lagom1-java-conductr-bundle-lib_2.11" % "1.1.3")
+      val result = Library.lagomConductrBundleLib(language = "java", lagomVersion = "1.3.5", scalaVersion = "2.11", conductrLibVersion = "2.0.0")
+      result shouldBe ("com.typesafe.conductr" % s"lagom13-java-conductr-bundle-lib_2.11" % "2.0.0")
     }
   }
 }


### PR DESCRIPTION
Now uses conductr-lib 2.0 for Akka 2.5 and Play 2.6 support.