### PR TITLE
Version bump for Lagom 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - conduct load -q visualizer
   - conduct load -q conductr-elasticsearch
   - conduct load -q conductr-kibana
+  - conduct load -q conductr-haproxy conductr-haproxy-dev-mode
   - conduct load -q continuous-delivery
   - sandbox stop
   # Tests go faster if we do this... less interactions with bintray etc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - conduct load -q visualizer
   - conduct load -q conductr-elasticsearch
   - conduct load -q conductr-kibana
+  - conduct load -q continuous-delivery
   - sandbox stop
   # Tests go faster if we do this... less interactions with bintray etc.
   - export CONDUCTR_OFFLINE_MODE=1

--- a/src/main/scala/com/lightbend/conductr/sbt/package.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/package.scala
@@ -76,7 +76,7 @@ package object sbt {
   }
 
   object Version {
-    val conductrBundleLib = "2.0.0"
+    val conductrBundleLib = "2.1.0"
   }
 
   /**

--- a/src/sbt-test/private/sandbox-conductr-roles/test
+++ b/src/sbt-test/private/sandbox-conductr-roles/test
@@ -1,10 +1,10 @@
-> sandbox run 2.0.5 --no-default-features --nr-of-instances 3:3
+> sandbox run 2.0.8 --no-default-features --nr-of-instances 3
 
 > checkConductrRolesByBundle
 
 > sandbox stop
 
-> sandbox run 2.0.5 --no-default-features --nr-of-instances 3:3 --conductr-role new-role --conductr-role other-role
+> sandbox run 2.0.8 --no-default-features --nr-of-instances 3 --conductr-role new-role --conductr-role other-role
 
 > checkConductrRolesBySandboxKey
 

--- a/src/sbt-test/private/sandbox-end-to-end/build.sbt
+++ b/src/sbt-test/private/sandbox-end-to-end/build.sbt
@@ -20,9 +20,9 @@ BundleKeys.diskSpace := 10.MB
 
 def resolveRunningContainers = """sandbox ps -q""".lines_!
 
-val checkInstances3 = taskKey[Unit]("Check that 6 instances of cores and agents are running.")
-checkInstances3 := {
-  resolveRunningContainers should have size 6
+val checkInstances2 = taskKey[Unit]("Check that 4 instances of cores and agents are running.")
+checkInstances2 := {
+  resolveRunningContainers should have size 4
 }
 
 /**

--- a/src/sbt-test/private/sandbox-end-to-end/test
+++ b/src/sbt-test/private/sandbox-end-to-end/test
@@ -1,7 +1,7 @@
-> sandbox run 2.0.5 --nr-of-instances 3:3 --port 1111 --port 2222 --port 2551
+> sandbox run 2.0.8 --nr-of-instances 2:2 --port 1111 --port 2222 --port 2551 --no-default-features -f lite-logging -f oci-in-docker -f proxying
 
 # sandbox checks
-> checkInstances3
+> checkInstances2
 > checkPorts
 
 > sandbox stop

--- a/src/sbt-test/public/conduct-end-to-end/test
+++ b/src/sbt-test/public/conduct-end-to-end/test
@@ -1,5 +1,5 @@
 # run sandbox
-> sandbox run 2.0.5
+> sandbox run 2.0.5  --no-default-features -f lite-logging
 
 # conduct members
 > conduct members

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/test
@@ -5,7 +5,7 @@
 ## script is created.
 ##
 
-> sandbox run 2.0.5
+> sandbox run 2.0.5 --no-default-features -f proxying -f oci-in-docker
 
 > install
 

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/test
@@ -6,7 +6,7 @@
 ## script is created.
 ##
 
-> sandbox run 2.0.5
+> sandbox run 2.0.5 --no-default-features -f proxying -f oci-in-docker
 
 > install
 

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/test
@@ -6,7 +6,7 @@
 ## script is created.
 ##
 
-> sandbox run 2.0.5
+> sandbox run 2.0.5 --no-default-features -f proxying -f oci-in-docker
 
 > install
 

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/test
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/test
@@ -5,7 +5,7 @@
 ## script is created.
 ##
 
-> sandbox run 2.0.5
+> sandbox run 2.0.5 --no-default-features -f proxying -f oci-in-docker
 
 > install
 

--- a/src/sbt-test/public/sandbox-ports-override-endpoints/test
+++ b/src/sbt-test/public/sandbox-ports-override-endpoints/test
@@ -1,4 +1,4 @@
-> sandbox run 2.0.5
+> sandbox run 2.0.5  --no-default-features -f proxying -f oci-in-docker
 
 > checkPorts
 


### PR DESCRIPTION
`conductr-lib` `2.1.0` will be released on Felix's Monday with support for Lagom 1.4. This updates `sbt-conductr` to use that version.