### PR TITLE
Cross-publish SBT 0.13/1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python: 3.5
 language: scala
 services: docker
 
+env:
+  - SBT_COMMAND=test-013
+  - SBT_COMMAND=test-10
+
 install:
   - sudo apt-get -qqy update
   - sudo apt-get -qqy install python3-setuptools
@@ -36,4 +40,4 @@ install:
   # Tests go faster if we do this... less interactions with bintray etc.
   - export CONDUCTR_OFFLINE_MODE=1
 
-script: sbt "scripted public/*"
+script: sbt "$SBT_COMMAND"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,14 +5,21 @@
 import sbt._
 
 object Version {
+  val config            = "1.3.1"
   val nativePackager    = "1.3.2"
-  val play              = "2.3.10" // Using Play 2.3 to use Scala 2.10 library
-  val scalaTest         = "2.2.6"
-  val scala             = "2.10.6"
+  val play              = "2.6.8" // Need to use a Play version that's published for 2.10 and 2.12
+  val sbt013            = "0.13.16"
+  val sbt10             = "1.0.3"
+  val scalaTest         = "3.0.4"
+  val scala210          = "2.10.6"
+  val scala212          = "2.12.4"
+  val sjsonnew          = "0.8.2"
 }
 
 object Library {
+  val config                 = "com.typesafe"          %  "config"                      % Version.config
   val nativePackager         = "com.typesafe.sbt"      %  "sbt-native-packager"         % Version.nativePackager
   val playJson               = "com.typesafe.play"     %% "play-json"                   % Version.play
   val scalaTest              = "org.scalatest"         %% "scalatest"                   % Version.scalaTest % "test"
+  val sjsonnew               = "com.eed3si9n"          %% "sjson-new-core"              % Version.sjsonnew
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.16

--- a/sbt-conductr-tester/bundle/project/build.properties
+++ b/sbt-conductr-tester/bundle/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/sbt-conductr-tester/lagom-java-bundle/project/build.properties
+++ b/sbt-conductr-tester/lagom-java-bundle/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.13

--- a/sbt-conductr-tester/lagom-scala-bundle/project/build.properties
+++ b/sbt-conductr-tester/lagom-scala-bundle/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/sbt-conductr-tester/play-bundle/project/build.properties
+++ b/sbt-conductr-tester/play-bundle/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/private/sandbox-all-args/project/build.properties
+++ b/src/sbt-test/private/sandbox-all-args/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/private/sandbox-all-args/project/plugins.sbt
+++ b/src/sbt-test/private/sandbox-all-args/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/private/sandbox-conductr-roles/project/build.properties
+++ b/src/sbt-test/private/sandbox-conductr-roles/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/private/sandbox-conductr-roles/project/plugins.sbt
+++ b/src/sbt-test/private/sandbox-conductr-roles/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/private/sandbox-end-to-end/project/build.properties
+++ b/src/sbt-test/private/sandbox-end-to-end/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/private/sandbox-end-to-end/project/plugins.sbt
+++ b/src/sbt-test/private/sandbox-end-to-end/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-acl-no-service-name/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-acl-no-service-name/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-acl-no-service-name/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-acl-no-service-name/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-basic/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-basic/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-basic/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-basic/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-bundle-config/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-bundle-config/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-bundle-config/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-bundle-config/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-bundle-plugin-acl-empty-request-mapping/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-bundle-plugin-acl-empty-request-mapping/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-bundle-plugin-acl-empty-request-mapping/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-bundle-plugin-acl-empty-request-mapping/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-checks/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-checks/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.7

--- a/src/sbt-test/public/bundle-plugin-checks/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-checks/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-overlays/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-overlays/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-overlays/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-overlays/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-validation-acl-and-service/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-validation-acl-and-service/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-validation-acl-and-service/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-validation-acl-and-service/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-validation-conductr-version-compatibility/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-validation-conductr-version-compatibility/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-validation-conductr-version-compatibility/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-validation-conductr-version-compatibility/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/bundle-plugin-validation-min-memory/project/build.properties
+++ b/src/sbt-test/public/bundle-plugin-validation-min-memory/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/bundle-plugin-validation-min-memory/project/plugins.sbt
+++ b/src/sbt-test/public/bundle-plugin-validation-min-memory/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/conduct-common-args/project/build.properties
+++ b/src/sbt-test/public/conduct-common-args/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/public/conduct-common-args/project/plugins.sbt
+++ b/src/sbt-test/public/conduct-common-args/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/conduct-end-to-end/project/build.properties
+++ b/src/sbt-test/public/conduct-end-to-end/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/public/conduct-end-to-end/project/plugins.sbt
+++ b/src/sbt-test/public/conduct-end-to-end/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects-single-acl/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-multi-projects/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-java/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-play-and-lagom-service-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-java/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/build.properties
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-bundle-plugin-with-service-endpoint-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/project/Build.scala
@@ -34,7 +34,7 @@ object DevModeBuild {
     val builder = new AsyncHttpClientConfig.Builder(config)
     val wsClient:WSClient = new NingWSClient(builder.build())
     val future = wsClient.url(uri).get().map(_.body)
-    Await.ready(future, Duration(1, "seconds"))
+    Await.ready(future, Duration(10, "seconds"))
     future.value.get
   }
 

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-java-service/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"
 
 // play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
 // available in Resolver.typesafeRepo("releases")

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/Build.scala
@@ -34,7 +34,7 @@ object DevModeBuild {
     val builder = new AsyncHttpClientConfig.Builder(config)
     val wsClient:WSClient = new NingWSClient(builder.build())
     val future = wsClient.url(uri).get().map(_.body)
-    Await.ready(future, Duration(1, "seconds"))
+    Await.ready(future, Duration(10, "seconds"))
     future.value.get
   }
 

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-java-service/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"
 
 // play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
 // available in Resolver.typesafeRepo("releases")

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/Build.scala
@@ -34,7 +34,7 @@ object DevModeBuild {
     val builder = new AsyncHttpClientConfig.Builder(config)
     val wsClient:WSClient = new NingWSClient(builder.build())
     val future = wsClient.url(uri).get().map(_.body)
-    Await.ready(future, Duration(1, "seconds"))
+    Await.ready(future, Duration(10, "seconds"))
     future.value.get
   }
 

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-legacy-scala-service/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.3.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"
 
 // play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
 // available in Resolver.typesafeRepo("releases")

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/Build.scala
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/Build.scala
@@ -34,7 +34,7 @@ object DevModeBuild {
     val builder = new AsyncHttpClientConfig.Builder(config)
     val wsClient:WSClient = new NingWSClient(builder.build())
     val future = wsClient.url(uri).get().map(_.body)
-    Await.ready(future, Duration(1, "seconds"))
+    Await.ready(future, Duration(10, "seconds"))
     future.value.get
   }
 

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/build.properties
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.16

--- a/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
+++ b/src/sbt-test/public/lagom-conductr-plugin-scala-service/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"
 
 // play-ws_2.10-2.3.10 depends on  com.typesafe.netty#netty-http-pipelining;1.1.2 which is only
 // available in Resolver.typesafeRepo("releases")

--- a/src/sbt-test/public/play-bundle-plugin-custom-config/project/build.properties
+++ b/src/sbt-test/public/play-bundle-plugin-custom-config/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/play-bundle-plugin-custom-config/project/plugins.sbt
+++ b/src/sbt-test/public/play-bundle-plugin-custom-config/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/play-bundle-plugin-play24/project/build.properties
+++ b/src/sbt-test/public/play-bundle-plugin-play24/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/play-bundle-plugin-play24/project/plugins.sbt
+++ b/src/sbt-test/public/play-bundle-plugin-play24/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.1")
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/play-bundle-plugin-play25/project/build.properties
+++ b/src/sbt-test/public/play-bundle-plugin-play25/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11

--- a/src/sbt-test/public/play-bundle-plugin-play25/project/plugins.sbt
+++ b/src/sbt-test/public/play-bundle-plugin-play25/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"

--- a/src/sbt-test/public/sandbox-ports-override-endpoints/project/build.properties
+++ b/src/sbt-test/public/sandbox-ports-override-endpoints/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version = 0.13.11

--- a/src/sbt-test/public/sandbox-ports-override-endpoints/project/plugins.sbt
+++ b/src/sbt-test/public/sandbox-ports-override-endpoints/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5"


### PR DESCRIPTION
This cross publishes sbt-conductr for both SBT 0.13 and 1.0. Once merged, we'll need to release version `2.7.0`.